### PR TITLE
Fix player creation schema

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -75,7 +75,6 @@ async def update_player(player_id: int, player: PlayerUpdate, db: Session = Depe
 class PlayerCreate(BaseModel):
     full_name: str
     parent_email: str
-    jersey_number: int
 
 @app.post("/players")
 def create_player(player: PlayerCreate, db: Session = Depends(get_db)):


### PR DESCRIPTION
## Summary
- `PlayerCreate` model no longer requires a jersey number since it is assigned automatically

## Testing
- `python3 -m py_compile app/main.py`
- `python3 -m py_compile app/email.py app/services/assign.py app/database.py app/models.py app/seed_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68539b771870832783585b1d60be09b3