### PR TITLE
Add tests for jersey assignment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 psycopg2-binary
 jinja2
 python-multipart
+pytest

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -1,0 +1,55 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure database URL is set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from app.database import Base
+from app.models import Player, Registration
+from app.services.assign import assign_jersey_number
+
+import pytest
+
+@pytest.fixture
+def db_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+def test_assign_returns_lowest_unused(db_session):
+    for num in [1, 2, 4]:
+        player = Player(full_name=f'Player {num}', jersey_number=num, parent_email='p@example.com')
+        db_session.add(player)
+        db_session.flush()
+        reg = Registration(
+            player_id=player.id,
+            program='prog',
+            division='U8',
+            sport='sport',
+            season='2024'
+        )
+        db_session.add(reg)
+    db_session.commit()
+    assert assign_jersey_number(db_session, 'U8') == 3
+
+def test_assign_fallback_when_all_taken(db_session):
+    for num in range(1, 100):
+        player = Player(full_name=f'Player {num}', jersey_number=num, parent_email=f'p{num}@ex.com')
+        db_session.add(player)
+        db_session.flush()
+        reg = Registration(
+            player_id=player.id,
+            program='prog',
+            division='U8',
+            sport='sport',
+            season='2024'
+        )
+        db_session.add(reg)
+    db_session.commit()
+    assert assign_jersey_number(db_session, 'U8') == 99


### PR DESCRIPTION
## Summary
- add pytest to requirements
- test jersey number assignment logic using SQLite in-memory DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539d3f7c4483278aa28dbeea2a6e40