### PR TITLE
Add admin stats overview

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -31,8 +31,15 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     players = db.query(Player).all()
     division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
     players_by_sport = defaultdict(lambda: defaultdict(list))
+    missing_emails = 0
+    missing_jerseys = 0
 
     for player in players:
+        if not player.parent_email:
+            missing_emails += 1
+        if not player.jersey_number:
+            missing_jerseys += 1
+
         for reg in player.registrations:
             players_by_sport[reg.sport][reg.division].append({
                 "id": player.id,
@@ -54,6 +61,8 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
         "request": request,
         "players_by_sport": sorted_players_by_sport,
         "total_players": len(players),
+        "missing_emails": missing_emails,
+        "missing_jerseys": missing_jerseys,
     })
 
 class PlayerUpdate(BaseModel):

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,7 +1,26 @@
 {% extends "base.html" %}
 {% block title %}POSA Admin{% endblock %}
 {% block content %}
-<p>Total players: {{ total_players }}</p>
+<div class="row mb-4">
+    <div class="col-md-4 mb-2">
+        <div class="bg-light border rounded p-3 text-center">
+            <h5 class="mb-0">{{ total_players }}</h5>
+            <small>Total Athletes</small>
+        </div>
+    </div>
+    <div class="col-md-4 mb-2">
+        <div class="bg-light border rounded p-3 text-center">
+            <h5 class="mb-0">{{ missing_emails }}</h5>
+            <small>Missing Emails</small>
+        </div>
+    </div>
+    <div class="col-md-4 mb-2">
+        <div class="bg-light border rounded p-3 text-center">
+            <h5 class="mb-0">{{ missing_jerseys }}</h5>
+            <small>Missing Jersey #</small>
+        </div>
+    </div>
+</div>
 <!-- Sport Tabs -->
 <ul class="nav nav-tabs" id="sportTabs" role="tablist">
     {% for sport, divisions in players_by_sport.items() %}


### PR DESCRIPTION
## Summary
- present quick stats on admin page
- tally players missing information in FastAPI admin route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685428d2a9a883278368da59ea95772a