### PR TITLE
Reduce POSA logo size

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,8 +7,14 @@
     <link href="https://cdn.prod.website-files.com/681d81085457ff1ea60182c2/css/posa-sports.webflow.shared.f686eb855.css" rel="stylesheet">
     <style>
         body { font-family: 'Generalsans', Arial, sans-serif; }
-        .navbar-posa { background-color: #0d1932; }
+        .navbar-posa {
+            background-color: #0d1932;
+            min-height: 56px; /* keep heading box size consistent */
+        }
         .navbar-posa .navbar-brand, .navbar-posa .nav-link { color: #fff; }
+        .navbar-posa .navbar-brand img {
+            height: 32px; /* logo slightly smaller */
+        }
         .navbar-posa .nav-link:hover { color: #fff; opacity: 0.8; }
 
         /* Override Webflow styles for Bootstrap nav components */
@@ -38,7 +44,7 @@
 <nav class="navbar navbar-expand-lg navbar-posa mb-4">
     <div class="container-fluid">
         <a class="navbar-brand" href="/">
-            <img src="https://cdn.prod.website-files.com/681d81085457ff1ea60182c2/681d813917159309836fda90_posa_white.svg" alt="POSA" height="40">
+            <img src="https://cdn.prod.website-files.com/681d81085457ff1ea60182c2/681d813917159309836fda90_posa_white.svg" alt="POSA">
         </a>
     </div>
 </nav>


### PR DESCRIPTION
## Summary
- set a minimum height for the navbar so the header keeps its size
- shrink the POSA logo image within the header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543d77b92c83278722d150d43ff8b1