### PR TITLE
Add user login system

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,21 @@
+from sqlalchemy.orm import Session
+from passlib.hash import bcrypt
+
+from .models import User
+
+
+def create_user(db: Session, email: str, password: str) -> User:
+    """Create a user with hashed password."""
+    user = User(email=email, password_hash=bcrypt.hash(password))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def authenticate_user(db: Session, email: str, password: str) -> User | None:
+    """Return user if credentials are valid."""
+    user = db.query(User).filter(User.email == email).first()
+    if user and bcrypt.verify(password, user.password_hash):
+        return user
+    return None

--- a/app/main.py
+++ b/app/main.py
@@ -1,19 +1,36 @@
 from fastapi import FastAPI, Depends, Request, Form, status, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
+from fastapi.middleware.sessions import SessionMiddleware
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 from .database import Base, engine, SessionLocal
-from .models import Player, Registration
+from .models import Player, Registration, User
+from .auth import authenticate_user, create_user
 from .services.assign import assign_jersey_number
 from .email import send_confirmation_email, process_inbound_email
 from collections import defaultdict
 import csv
 import io
+import os
 
 app = FastAPI()
+app.add_middleware(SessionMiddleware, secret_key=os.getenv("SECRET_KEY", "secret-key"))
 templates = Jinja2Templates(directory="app/templates")
 Base.metadata.create_all(bind=engine)
+
+
+@app.on_event("startup")
+def ensure_admin_user() -> None:
+    """Create initial admin user if none exist."""
+    db = SessionLocal()
+    try:
+        if not db.query(User).first():
+            email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+            password = os.getenv("ADMIN_PASSWORD", "admin")
+            create_user(db, email, password)
+    finally:
+        db.close()
 
 def get_db():
     db = SessionLocal()
@@ -22,12 +39,63 @@ def get_db():
     finally:
         db.close()
 
+
+def require_login(request: Request):
+    """Redirect to login if user not authenticated."""
+    if not request.session.get("user_id"):
+        raise HTTPException(status_code=status.HTTP_303_SEE_OTHER, headers={"Location": "/login"})
+
 @app.get("/")
 def read_root():
     return {"message": "POSA Jersey App is running!"}
 
+
+@app.get("/login", response_class=HTMLResponse)
+def login_form(request: Request):
+    return templates.TemplateResponse("login.html", {"request": request, "error": None})
+
+
+@app.post("/login")
+def login(request: Request, email: str = Form(...), password: str = Form(...), db: Session = Depends(get_db)):
+    user = authenticate_user(db, email, password)
+    if not user:
+        return templates.TemplateResponse("login.html", {"request": request, "error": "Invalid credentials"}, status_code=400)
+    request.session["user_id"] = user.id
+    return RedirectResponse("/admin", status_code=302)
+
+
+@app.get("/logout")
+def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse("/login", status_code=302)
+
+
+@app.get("/invite", response_class=HTMLResponse)
+def invite_form(request: Request):
+    try:
+        require_login(request)
+    except HTTPException as exc:
+        return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
+    return templates.TemplateResponse("invite_user.html", {"request": request, "error": None})
+
+
+@app.post("/invite")
+def invite_user(request: Request, email: str = Form(...), password: str = Form(...), db: Session = Depends(get_db)):
+    try:
+        require_login(request)
+    except HTTPException as exc:
+        return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
+    if db.query(User).filter(User.email == email).first():
+        return templates.TemplateResponse("invite_user.html", {"request": request, "error": "User already exists"}, status_code=400)
+    create_user(db, email, password)
+    return RedirectResponse("/admin", status_code=302)
+
 @app.get("/admin", response_class=HTMLResponse)
 def admin_dashboard(request: Request, db: Session = Depends(get_db)):
+    try:
+        require_login(request)
+    except HTTPException as exc:
+        return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
     players = db.query(Player).all()
     division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
     players_by_sport = defaultdict(lambda: defaultdict(list))
@@ -71,7 +139,8 @@ class PlayerUpdate(BaseModel):
     jersey_number: int
 
 @app.put("/players/{player_id}")
-async def update_player(player_id: int, player: PlayerUpdate, db: Session = Depends(get_db)):
+async def update_player(player_id: int, player: PlayerUpdate, request: Request, db: Session = Depends(get_db)):
+    require_login(request)
     db_player = db.query(Player).get(player_id)
     if db_player:
         db_player.full_name = player.full_name
@@ -88,7 +157,8 @@ class PlayerCreate(BaseModel):
     parent_email: str
 
 @app.post("/players")
-def create_player(player: PlayerCreate, db: Session = Depends(get_db)):
+def create_player(player: PlayerCreate, request: Request, db: Session = Depends(get_db)):
+    require_login(request)
     dummy_division = "U6"
     jersey_number = assign_jersey_number(db, dummy_division)
     db_player = Player(
@@ -102,7 +172,8 @@ def create_player(player: PlayerCreate, db: Session = Depends(get_db)):
     return db_player
 
 @app.get("/export")
-def export_players_csv(db: Session = Depends(get_db)):
+def export_players_csv(request: Request, db: Session = Depends(get_db)):
+    require_login(request)
     players = db.query(Player).all()
     output = io.StringIO()
     writer = csv.writer(output)
@@ -113,7 +184,8 @@ def export_players_csv(db: Session = Depends(get_db)):
     return StreamingResponse(io.BytesIO(output.getvalue().encode()), media_type="text/csv")
 
 @app.delete("/players/{player_id}")
-def delete_player(player_id: int, db: Session = Depends(get_db)):
+def delete_player(player_id: int, request: Request, db: Session = Depends(get_db)):
+    require_login(request)
     player = db.query(Player).get(player_id)
     if player:
         db.delete(player)
@@ -135,7 +207,8 @@ async def receive_email(request: Request, db: Session = Depends(get_db)):
 
 
 @app.post("/registrations/{registration_id}/send_email")
-def send_registration_email(registration_id: int, db: Session = Depends(get_db)):
+def send_registration_email(registration_id: int, request: Request, db: Session = Depends(get_db)):
+    require_login(request)
     reg = db.query(Registration).get(registration_id)
     if not reg:
         raise HTTPException(status_code=404, detail="Registration not found")

--- a/app/models.py
+++ b/app/models.py
@@ -40,3 +40,13 @@ class Registration(Base):
     __table_args__ = (
         UniqueConstraint("player_id", "sport", "season", name="uq_player_sport_season"),
     )
+
+
+class User(Base):
+    """Application user."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,6 +46,14 @@
         <a class="navbar-brand" href="/">
             <img src="https://cdn.prod.website-files.com/681d81085457ff1ea60182c2/681d813917159309836fda90_posa_white.svg" alt="POSA">
         </a>
+        <div class="ms-auto">
+            {% if request.session.get('user_id') %}
+            <a class="nav-link d-inline text-white" href="/invite">Invite User</a>
+            <a class="nav-link d-inline text-white" href="/logout">Logout</a>
+            {% else %}
+            <a class="nav-link d-inline text-white" href="/login">Login</a>
+            {% endif %}
+        </div>
     </div>
 </nav>
 <div class="container">

--- a/app/templates/invite_user.html
+++ b/app/templates/invite_user.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Invite User{% endblock %}
+{% block content %}
+<h2>Invite User</h2>
+<form method="post">
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Create User</button>
+</form>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psycopg2-binary
 jinja2
 python-multipart
 pytest
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- implement basic `User` model
- add authentication helpers using passlib
- require login for admin-related routes
- create login and invite user pages
- add new navbar links when logged in
- ensure an admin user is created on startup

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685443ee3b988327b891d1a12b992d3e