### PR TITLE
Remove invalid import causing deployment failure

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI, Depends, Request, Form, status, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
-from fastapi.middleware.sessions import SessionMiddleware
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 from .database import Base, engine, SessionLocal


### PR DESCRIPTION
## Summary
- fix import statement for `SessionMiddleware`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685462f763d8832798a6eefb22f1c4ad