### PR TITLE
Add promo code column and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+__pycache__/
+venv/

--- a/alembic/versions/add_promo_code_to_registration.py
+++ b/alembic/versions/add_promo_code_to_registration.py
@@ -1,0 +1,16 @@
+"""add promo_code to registration"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '70cdcc468f06'
+down_revision = '067e47789ef7'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column('registrations', sa.Column('promo_code', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('registrations', 'promo_code')

--- a/app/email.py
+++ b/app/email.py
@@ -7,27 +7,46 @@ from sendgrid.helpers.mail import Mail
 from .models import Player, Registration
 from .services.assign import assign_jersey_number
 
+# Promo code mapping based on number of registrations in a single email
+PROMO_CODES = {
+    1: "Pines1Player",
+    2: "Pines2Players",
+    3: "Pines3Players",
+    4: "Pines4Players",
+    5: "Pines5Players",
+    6: "Pines6Players",
+    7: "Pines7Players",
+}
+
 print("📬 Loaded email.py")
 
 # Simplified for local/dev use – no actual email sending, just update flag
-def send_confirmation_email(to_email, player_name, jersey_number, order_url, registration=None, db=None):
-    print(f"[DEV MODE] Skipping sending email to {to_email} for {player_name} (#{jersey_number})")
+def send_confirmation_email(to_email, player_name, jersey_number, order_url, registration=None, db=None, promo_code=None):
+    if promo_code is None and registration is not None:
+        promo_code = getattr(registration, "promo_code", None)
+    promo_msg = f" Promo code: {promo_code}" if promo_code else ""
+    print(
+        f"[DEV MODE] Skipping sending email to {to_email} for {player_name} (#{jersey_number}){promo_msg}"
+    )
 
     if registration and db:
         registration.confirmation_sent = True
         db.commit()
 
 # Optional: uncomment to send actual emails in production
-# def send_confirmation_email(to_email, player_name, jersey_number, order_url, registration=None, db=None):
+# def send_confirmation_email(to_email, player_name, jersey_number, order_url, registration=None, db=None, promo_code=None):
+#     html = f"""
+#         <p>Hi {player_name},</p>
+#         <p>Your jersey number is <strong>{jersey_number}</strong>.</p>
+#     """
+#     if promo_code:
+#         html += f"<p>Your promo code is <strong>{promo_code}</strong>. Use it during checkout for your free jersey.</p>"
+#     html += f'<p>You can order your uniform here: <a href="{order_url}">Order Jersey</a></p>'
 #     message = Mail(
 #         from_email="noreply@posasports.org",
 #         to_emails=to_email,
 #         subject="Your POSA Jersey Number",
-#         html_content=f"""
-#         <p>Hi {player_name},</p>
-#         <p>Your jersey number is <strong>{jersey_number}</strong>.</p>
-#         <p>You can order your uniform here: <a href="{order_url}">Order Jersey</a></p>
-#         """
+#         html_content=html,
 #     )
 #     try:
 #         sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
@@ -62,6 +81,8 @@ def process_inbound_email(email_body: str, db):
 
     if current_block:
         registrant_blocks.append(current_block)
+
+    parsed_regs = []
 
     for block in registrant_blocks:
         full_text = "\n".join(block)
@@ -108,37 +129,69 @@ def process_inbound_email(email_body: str, db):
                     sport = s
                     break
 
-            player = db.query(Player).filter_by(full_name=full_name).first()
-
-            if not player:
-                jersey_number = assign_jersey_number(db, division)
-                player = Player(full_name=full_name, parent_email=parent_email, jersey_number=jersey_number)
-                db.add(player)
-                db.commit()
-                db.refresh(player)
-
-            existing_reg = db.query(Registration).filter_by(
-                player_id=player.id,
-                division=division,
-                season=season,
-                sport=sport
-            ).first()
-
-            if not existing_reg:
-                reg = Registration(
-                    player_id=player.id,
-                    program=program,
-                    division=division,
-                    sport=sport,
-                    season=season,
-                    order_number=order_number,
-                    order_date=order_date,
-                    confirmation_sent=False
-                )
-                db.add(reg)
-                db.commit()
-            else:
-                print(f"✔ Registration already exists for {player.full_name} in {division} {sport} {season}")
+            parsed_regs.append({
+                "full_name": full_name,
+                "program": program,
+                "division": division,
+                "parent_email": parent_email,
+                "order_number": order_number,
+                "order_date": order_date,
+                "sport": sport,
+                "season": season,
+            })
 
         except Exception as e:
             print(f"❌ Error processing registrant block: {e}")
+
+    promo_code = PROMO_CODES.get(len(parsed_regs))
+
+    for entry in parsed_regs:
+        player = db.query(Player).filter_by(full_name=entry["full_name"]).first()
+
+        if not player:
+            jersey_number = assign_jersey_number(db, entry["division"])
+            player = Player(
+                full_name=entry["full_name"],
+                parent_email=entry["parent_email"],
+                jersey_number=jersey_number,
+            )
+            db.add(player)
+            db.commit()
+            db.refresh(player)
+
+        existing_reg = db.query(Registration).filter_by(
+            player_id=player.id,
+            division=entry["division"],
+            season=entry["season"],
+            sport=entry["sport"],
+        ).first()
+
+        if not existing_reg:
+            reg = Registration(
+                player_id=player.id,
+                program=entry["program"],
+                division=entry["division"],
+                sport=entry["sport"],
+                season=entry["season"],
+                order_number=entry["order_number"],
+                order_date=entry["order_date"],
+                confirmation_sent=False,
+                promo_code=promo_code,
+            )
+            db.add(reg)
+            db.commit()
+
+            # Auto email sending disabled. Uncomment to enable.
+            # send_confirmation_email(
+            #     player.parent_email,
+            #     player.full_name,
+            #     player.jersey_number,
+            #     "https://your-order-url.com",
+            #     reg,
+            #     db,
+            #     promo_code=reg.promo_code,
+            # )
+        else:
+            print(
+                f"✔ Registration already exists for {player.full_name} in {entry['division']} {entry['sport']} {entry['season']}"
+            )

--- a/app/main.py
+++ b/app/main.py
@@ -220,5 +220,6 @@ def send_registration_email(registration_id: int, request: Request, db: Session 
         "https://your-order-url.com",
         reg,
         db,
+        promo_code=reg.promo_code,
     )
     return {"message": "Email sent"}

--- a/app/models.py
+++ b/app/models.py
@@ -31,6 +31,7 @@ class Registration(Base):
     season = Column(String, nullable=False)
     order_number = Column(String, nullable=True)
     order_date = Column(DateTime, nullable=True)
+    promo_code = Column(String, nullable=True)
 
     confirmation_sent = Column(Boolean, default=False)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/scripts/mark_single_registrations.py
+++ b/scripts/mark_single_registrations.py
@@ -1,0 +1,21 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.models import Registration
+from app.database import Base
+
+DATABASE_URL = "sqlite:///./app.db"
+engine = create_engine(DATABASE_URL)
+Session = sessionmaker(bind=engine)
+
+
+def main():
+    session = Session()
+    regs = session.query(Registration).filter(Registration.promo_code == None).all()
+    for reg in regs[:6]:
+        reg.promo_code = "Pines1Player"
+    session.commit()
+    print(f"Updated {min(len(regs),6)} registrations")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,0 +1,41 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from app.database import Base
+from app.models import Player, Registration
+from app.email import process_inbound_email
+
+import pytest
+
+@pytest.fixture
+def db_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_promo_code_assignment(db_session):
+    email = """
+Name: Player One
+Program: Winter Soccer
+Division: U10
+Parent Email: p1@example.com
+
+Name: Player Two
+Program: Winter Soccer
+Division: U10
+Parent Email: p2@example.com
+"""
+    process_inbound_email(email, db_session)
+    regs = db_session.query(Registration).all()
+    assert len(regs) == 2
+    assert all(r.promo_code == 'Pines2Players' for r in regs)
+


### PR DESCRIPTION
## Summary
- store promo code in each registration
- include promo code when sending confirmation emails
- compute promo code when processing inbound email
- provide script to mark existing registrations as single players
- add migration and unit test for promo codes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854c52ba3d08327a706574aed2134bd