### PR TITLE
Handle HTML-only emails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-multipart
 sendgrid
 sqlalchemy
 uvicorn
+beautifulsoup4

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -1,0 +1,49 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+# Ensure database URL is set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from app.database import Base
+from app.models import Player, Registration
+from app.email import process_inbound_email
+
+import pytest
+
+@pytest.fixture
+def db_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+def test_html_email_parsing(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Test'
+    html = """
+    <html><body>
+    Name: John Doe<br>
+    Program: Fall Soccer<br>
+    Division: U10<br>
+    Parent Email: parent@example.com<br>
+    Order Number: 12345<br>
+    Order Date: January 1, 2024
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    player = db_session.query(Player).filter_by(full_name='John Doe').first()
+    assert player is not None
+    reg = db_session.query(Registration).filter_by(player_id=player.id).first()
+    assert reg is not None
+    assert reg.program == 'Fall Soccer'
+    assert reg.division == 'U10'


### PR DESCRIPTION
## Summary
- parse inbound email using the `email` module
- fall back to stripping HTML with BeautifulSoup
- make regex searches case-insensitive
- add BeautifulSoup dependency
- test email parser with an HTML MIME message

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6477ca8083279e26e38b5afcb03d