### PR TITLE
Improve error logging in email parser

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -108,8 +108,15 @@ def process_inbound_email(email_body: str, db):
             order_number_match = re.search(r"Order Number:\s*(.+)", full_text)
             order_date_match = re.search(r"Order Date:\s*(.+)", full_text)
 
-            if not all([name_match, program_match, division_match, parent_email_match]):
-                print("❌ Skipping incomplete entry")
+            missing = [key for key, match in {
+                "Name": name_match,
+                "Program": program_match,
+                "Division": division_match,
+                "Parent Email": parent_email_match,
+            }.items() if not match]
+
+            if missing:
+                print(f"❌ Skipping entry, missing: {', '.join(missing)}")
                 continue
 
             full_name = name_match.group(1).strip()

--- a/tests/test_process_email.py
+++ b/tests/test_process_email.py
@@ -1,0 +1,39 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure DATABASE_URL is set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from app.database import Base
+from app.email import process_inbound_email
+
+import pytest
+
+@pytest.fixture
+def db_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_logs_missing_single_field(db_session, capsys):
+    body = """Name: John Doe\nProgram: Spring Soccer\nParent Email: p@example.com"""
+    process_inbound_email(body, db_session)
+    captured = capsys.readouterr().out
+    assert "missing: Division" in captured
+
+
+def test_logs_missing_multiple_fields(db_session, capsys):
+    body = """Program: Spring Soccer\nDivision: U12"""
+    process_inbound_email(body, db_session)
+    captured = capsys.readouterr().out
+    # Order of fields may vary
+    assert "missing:" in captured
+    assert "Name" in captured
+    assert "Parent Email" in captured


### PR DESCRIPTION
## Summary
- handle missing regex matches in `process_inbound_email`
- add tests for new log format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6479bea48327a4b26af2591c9f0b