### PR TITLE
Enhance HTML order parsing

### DIFF
--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -10,6 +10,7 @@ os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
 from app.database import Base
 from app.models import Player, Registration
 from app.email import process_inbound_email
+from datetime import datetime
 
 import pytest
 
@@ -47,3 +48,33 @@ def test_html_email_parsing(db_session):
     assert reg is not None
     assert reg.program == 'Fall Soccer'
     assert reg.division == 'U10'
+
+
+def test_order_details_table_parsing(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg['To'] = 'parent@example.com'
+    html = """
+    <html><body>
+    <table>
+        <tr><td>Order Details</td></tr>
+        <tr><td>Order Number</td><td>ABC123</td></tr>
+        <tr><td>Order Date</td><td>January 2, 2024</td></tr>
+        <tr><td><span>John Doe</span></td><td><span>Fall Soccer - U10</span></td></tr>
+        <tr><td><span>Jane Doe</span></td><td><span>Fall Soccer - U8</span></td></tr>
+    </table>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    players = db_session.query(Player).order_by(Player.full_name).all()
+    assert [p.full_name for p in players] == ['Jane Doe', 'John Doe']
+    for player in players:
+        assert player.parent_email == 'parent@example.com'
+
+    regs = db_session.query(Registration).order_by(Registration.division).all()
+    assert len(regs) == 2
+    assert all(r.order_number == 'ABC123' for r in regs)
+    assert all(r.order_date.date() == datetime(2024, 1, 2).date() for r in regs)


### PR DESCRIPTION
## Summary
- parse HTML payload when plain text regex fails
- capture order details from HTML table rows
- add new unit test for order-details table parsing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d708588d483279a174bfd0a7bdfdc