### PR TITLE
Add Bluesombrero email fixture and parsing test

### DIFF
--- a/tests/fixtures/bluesombrero_order.html
+++ b/tests/fixtures/bluesombrero_order.html
@@ -1,0 +1,10 @@
+<html>
+  <body>
+    Name: Sally Smith<br>
+    Program: Winter Basketball<br>
+    Division: U12<br>
+    Parent Email: sallyparent@example.com<br>
+    Order Number: 987654321<br>
+    Order Date: February 10, 2024
+  </body>
+</html>

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -49,6 +49,34 @@ def test_html_email_parsing(db_session):
     assert reg.program == 'Fall Soccer'
     assert reg.division == 'U10'
 
+def test_order_details_table_parsing(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg['To'] = 'parent@example.com'
+    html = """
+    <html><body>
+    <table>
+        <tr><td>Order Details</td></tr>
+        <tr><td>Order Number</td><td>ABC123</td></tr>
+        <tr><td>Order Date</td><td>January 2, 2024</td></tr>
+        <tr><td><span>John Doe</span></td><td><span>Fall Soccer - U10</span></td></tr>
+        <tr><td><span>Jane Doe</span></td><td><span>Fall Soccer - U8</span></td></tr>
+    </table>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    players = db_session.query(Player).order_by(Player.full_name).all()
+    assert [p.full_name for p in players] == ['Jane Doe', 'John Doe']
+    for player in players:
+        assert player.parent_email == 'parent@example.com'
+
+    regs = db_session.query(Registration).order_by(Registration.division).all()
+    assert len(regs) == 2
+    assert all(r.order_number == 'ABC123' for r in regs)
+    assert all(r.order_date.date() == datetime(2024, 1, 2).date() for r in regs)
 
 def test_bluesombrero_fixture_parsing(db_session):
     fixture = os.path.join('tests', 'fixtures', 'bluesombrero_order.html')

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -3,6 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from datetime import datetime
 
 # Ensure database URL is set before importing application modules
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
@@ -47,3 +48,26 @@ def test_html_email_parsing(db_session):
     assert reg is not None
     assert reg.program == 'Fall Soccer'
     assert reg.division == 'U10'
+
+
+def test_bluesombrero_fixture_parsing(db_session):
+    fixture = os.path.join('tests', 'fixtures', 'bluesombrero_order.html')
+    with open(fixture, 'r') as f:
+        html = f.read()
+
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    player = db_session.query(Player).filter_by(full_name='Sally Smith').first()
+    assert player is not None
+    assert player.parent_email == 'sallyparent@example.com'
+
+    reg = db_session.query(Registration).filter_by(player_id=player.id).first()
+    assert reg is not None
+    assert reg.program == 'Winter Basketball'
+    assert reg.division == 'U12'
+    assert reg.order_number == '987654321'
+    assert reg.order_date == datetime(2024, 2, 10)

--- a/tests/test_process_email.py
+++ b/tests/test_process_email.py
@@ -23,14 +23,21 @@ def db_session():
 
 
 def test_logs_missing_single_field(db_session, capsys):
-    body = """Name: John Doe\nProgram: Spring Soccer\nParent Email: p@example.com"""
+    body = """
+Name: John Doe
+Program: Spring Soccer
+Parent Email: p@example.com
+"""
     process_inbound_email(body, db_session)
     captured = capsys.readouterr().out
     assert "missing: Division" in captured
 
 
 def test_logs_missing_multiple_fields(db_session, capsys):
-    body = """Program: Spring Soccer\nDivision: U12"""
+    body = """
+Program: Spring Soccer
+Division: U12
+"""
     process_inbound_email(body, db_session)
     captured = capsys.readouterr().out
     # Order of fields may vary


### PR DESCRIPTION
## Summary
- fix plain text email tests by ensuring body is parsed as message content
- include captured Bluesombrero email fixture
- verify that process_inbound_email correctly parses HTML orders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7086d1308327ba059078f6bbe4e4