### PR TITLE
Add confirmation alert for email action

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -162,6 +162,7 @@
             const response = await fetch(`/registrations/${regId}/send_email`, { method: "POST" });
             if (response.ok) {
                 row.querySelector(".email-status").textContent = "✅";
+                alert("Confirmation email sent.");
             } else {
                 alert("Failed to send email.");
             }

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -49,11 +49,6 @@ def test_html_email_parsing(db_session):
     assert reg is not None
     assert reg.program == 'Fall Soccer'
     assert reg.division == 'U10'
-
- codex/add-test-for-email-parser
-
-
- main
 def test_order_details_table_parsing(db_session):
     msg = MIMEMultipart('alternative')
     msg['Subject'] = 'Order'
@@ -82,7 +77,6 @@ def test_order_details_table_parsing(db_session):
     assert len(regs) == 2
     assert all(r.order_number == 'ABC123' for r in regs)
     assert all(r.order_date.date() == datetime(2024, 1, 2).date() for r in regs)
- codex/add-test-for-email-parser
 
 def test_bluesombrero_fixture_parsing(db_session):
     fixture = os.path.join('tests', 'fixtures', 'bluesombrero_order.html')
@@ -105,5 +99,3 @@ def test_bluesombrero_fixture_parsing(db_session):
     assert reg.division == 'U12'
     assert reg.order_number == '987654321'
     assert reg.order_date == datetime(2024, 2, 10)
-
- main


### PR DESCRIPTION
## Summary
- show a popup after successfully sending an email
- clean stray text from `tests/test_email_parser.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d777b3eb48327a4ac84e65efa2540