### PR TITLE
Link logo to admin dashboard

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -43,7 +43,7 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-posa mb-4">
     <div class="container-fluid">
-        <a class="navbar-brand" href="/">
+        <a class="navbar-brand" href="/admin">
             <img src="https://cdn.prod.website-files.com/681d81085457ff1ea60182c2/681d813917159309836fda90_posa_white.svg" alt="POSA">
         </a>
         <div class="ms-auto">

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -49,11 +49,6 @@ def test_html_email_parsing(db_session):
     assert reg is not None
     assert reg.program == 'Fall Soccer'
     assert reg.division == 'U10'
-
- codex/add-test-for-email-parser
-
-
- main
 def test_order_details_table_parsing(db_session):
     msg = MIMEMultipart('alternative')
     msg['Subject'] = 'Order'
@@ -82,8 +77,6 @@ def test_order_details_table_parsing(db_session):
     assert len(regs) == 2
     assert all(r.order_number == 'ABC123' for r in regs)
     assert all(r.order_date.date() == datetime(2024, 1, 2).date() for r in regs)
- codex/add-test-for-email-parser
-
 def test_bluesombrero_fixture_parsing(db_session):
     fixture = os.path.join('tests', 'fixtures', 'bluesombrero_order.html')
     with open(fixture, 'r') as f:
@@ -105,5 +98,3 @@ def test_bluesombrero_fixture_parsing(db_session):
     assert reg.division == 'U12'
     assert reg.order_number == '987654321'
     assert reg.order_date == datetime(2024, 2, 10)
-
- main


### PR DESCRIPTION
## Summary
- adjust navbar so the POSA logo points to `/admin`
- clean up stray text in `tests/test_email_parser.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d775e3a608327af8fd7fda1ae544b