### PR TITLE
Add manual player creation UI

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,6 +48,7 @@
         </a>
         <div class="ms-auto">
             {% if request.session.get('user_id') %}
+            <a class="nav-link d-inline text-white" href="/players/new">Add Player</a>
             <a class="nav-link d-inline text-white" href="/invite">Invite User</a>
             <a class="nav-link d-inline text-white" href="/logout">Logout</a>
             {% else %}

--- a/app/templates/new_player.html
+++ b/app/templates/new_player.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Add Player{% endblock %}
+{% block content %}
+<h2>Add Player</h2>
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Full Name</label>
+        <input type="text" name="full_name" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Parent Email</label>
+        <input type="email" name="parent_email" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Sport</label>
+        <input type="text" name="sport" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Division</label>
+        <input type="text" name="division" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Season</label>
+        <input type="text" name="season" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Add Player</button>
+    <a href="/admin" class="btn btn-secondary ms-2">Cancel</a>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow adding players via `/players/new`
- show **Add Player** link in the navbar
- add template for new player form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7703a03c8327848271a81afb3f08