### PR TITLE
Add console message when sending email

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -162,6 +162,7 @@
             const response = await fetch(`/registrations/${regId}/send_email`, { method: "POST" });
             if (response.ok) {
                 row.querySelector(".email-status").textContent = "✅";
+                console.log("Email sent successfully");
             } else {
                 alert("Failed to send email.");
             }


### PR DESCRIPTION
## Summary
- log a confirmation in the browser console after sending a registration email

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d78a1a04c8327b8f2f7e8a88916ba