### PR TITLE
Enable manual player division changes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -248,6 +248,40 @@ def create_player_inline(player: InlinePlayerCreate, request: Request, db: Sessi
         "confirmation_sent": reg.confirmation_sent,
     }
 
+
+class DivisionUpdate(BaseModel):
+    division: str
+
+
+@app.put("/registrations/{registration_id}/division")
+def move_player_division(
+    registration_id: int,
+    payload: DivisionUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Move a player's registration to a new division and assign jersey."""
+    require_login(request)
+    reg = db.query(Registration).get(registration_id)
+    if not reg:
+        raise HTTPException(status_code=404, detail="Registration not found")
+
+    reg.division = payload.division
+    reg.player.jersey_number = assign_jersey_number(db, payload.division)
+    db.commit()
+    db.refresh(reg)
+
+    return {
+        "id": reg.player.id,
+        "registration_id": reg.id,
+        "full_name": reg.player.full_name,
+        "parent_email": reg.player.parent_email,
+        "jersey_number": reg.player.jersey_number,
+        "sport": reg.sport,
+        "division": reg.division,
+        "confirmation_sent": reg.confirmation_sent,
+    }
+
 @app.get("/export")
 def export_players_csv(request: Request, db: Session = Depends(get_db)):
     require_login(request)

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -74,6 +74,7 @@
                                             <button class="btn btn-sm btn-success btn-save d-none">Save</button>
                                             <button class="btn btn-sm btn-secondary btn-cancel d-none">Cancel</button>
                                             <button class="btn btn-sm btn-info btn-send-email">Email</button>
+                                            <button class="btn btn-sm btn-warning btn-move">Move</button>
                                             <button class="btn btn-sm btn-danger btn-delete">Delete</button>
                                         </td>
                                     </tr>
@@ -177,12 +178,32 @@
         }
     }
 
+    async function moveHandler(event) {
+        const row = event.currentTarget.closest("tr");
+        const regId = row.dataset.regId;
+        const newDivision = prompt("Enter new division:");
+        if (!newDivision) {
+            return;
+        }
+        const response = await fetch(`/registrations/${regId}/division`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ division: newDivision })
+        });
+        if (response.ok) {
+            location.reload();
+        } else {
+            alert("Failed to move player.");
+        }
+    }
+
     function attachRowHandlers(row) {
         row.querySelector(".btn-edit")?.addEventListener("click", editHandler);
         row.querySelector(".btn-cancel")?.addEventListener("click", cancelHandler);
         row.querySelector(".btn-save")?.addEventListener("click", saveHandler);
         row.querySelector(".btn-delete")?.addEventListener("click", deleteHandler);
         row.querySelector(".btn-send-email")?.addEventListener("click", emailHandler);
+        row.querySelector(".btn-move")?.addEventListener("click", moveHandler);
     }
 
     document.querySelectorAll("tbody tr[data-player-id]").forEach(attachRowHandlers);

--- a/tests/test_move_division.py
+++ b/tests/test_move_division.py
@@ -1,0 +1,74 @@
+import os
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Ensure DATABASE_URL set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from fastapi.testclient import TestClient
+import app.main as app_main
+from app.main import app, Base, get_db
+from app.models import Player, Registration
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    # bypass authentication and startup logic
+    app_main.require_login = lambda request: None
+    app.router.on_startup.clear()
+
+    with TestClient(app) as c:
+        c.SessionLocal = TestingSessionLocal
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def setup_players(SessionLocal):
+    db = SessionLocal()
+    # Player to move from U8
+    p1 = Player(full_name='Player1', parent_email='p1@example.com', jersey_number=1)
+    db.add(p1)
+    db.flush()
+    reg1 = Registration(player_id=p1.id, program='prog', division='U8', sport='soccer', season='2024')
+    db.add(reg1)
+    # existing players in target division taking jersey numbers 1 and 2
+    for num in [1, 2]:
+        px = Player(full_name=f'P{num}', parent_email=f'p{num}@ex.com', jersey_number=num)
+        db.add(px)
+        db.flush()
+        db.add(Registration(player_id=px.id, program='prog', division='U10', sport='soccer', season='2024'))
+    db.commit()
+    reg_id = reg1.id
+    db.close()
+    return reg_id
+
+
+def test_move_player_between_divisions(client):
+    reg_id = setup_players(client.SessionLocal)
+
+    response = client.put(f"/registrations/{reg_id}/division", json={'division': 'U10'})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['division'] == 'U10'
+    assert data['jersey_number'] == 3
+
+    db = client.SessionLocal()
+    reg = db.query(Registration).get(reg_id)
+    assert reg.division == 'U10'
+    assert reg.player.jersey_number == 3
+    db.close()


### PR DESCRIPTION
## Summary
- allow moving a player's registration between divisions with new jersey numbers
- add admin UI button for manual division changes
- test moving player to new division

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890e4603c248327ba02a57963ad9e54