### PR TITLE
Add CLI script for manual player creation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sendgrid
 sqlalchemy
 uvicorn
 beautifulsoup4
+httpx

--- a/scripts/add_player.py
+++ b/scripts/add_player.py
@@ -1,0 +1,37 @@
+import argparse
+from app.database import SessionLocal
+from app.models import Player, Registration
+from app.services.assign import assign_jersey_number
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Add a player and registration manually")
+    parser.add_argument("full_name")
+    parser.add_argument("parent_email")
+    parser.add_argument("sport")
+    parser.add_argument("division")
+    parser.add_argument("season")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        jersey = assign_jersey_number(db, args.division)
+        player = Player(full_name=args.full_name, parent_email=args.parent_email, jersey_number=jersey)
+        db.add(player)
+        db.flush()
+        reg = Registration(
+            player_id=player.id,
+            program=f"{args.season} {args.sport}",
+            division=args.division,
+            sport=args.sport.strip().lower(),
+            season=args.season,
+        )
+        db.add(reg)
+        db.commit()
+        print(f"Added player {player.full_name} (ID {player.id}) with jersey #{jersey}")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `scripts/add_player.py` to manually create a player and registration from the command line
- include httpx in requirements for running tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ea80fa788327a926814b585159e3