### PR TITLE
Ensure empty divisions appear in admin UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -121,6 +121,11 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
                 "confirmation_sent": reg.confirmation_sent,
             })
 
+    # Ensure each sport has entries for all divisions, even if no players
+    for sport in players_by_sport.keys():
+        for division in division_order.keys():
+            players_by_sport[sport].setdefault(division, [])
+
     sorted_players_by_sport = {}
     for sport, divisions in players_by_sport.items():
         sorted_divisions = dict(sorted(divisions.items(), key=lambda x: division_order.get(x[0], 999)))
@@ -129,6 +134,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     return templates.TemplateResponse("admin.html", {
         "request": request,
         "players_by_sport": sorted_players_by_sport,
+        "division_list": list(division_order.keys()),
         "total_players": len(players),
         "missing_emails": missing_emails,
         "missing_jerseys": missing_jerseys,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -35,7 +35,7 @@
     {% for sport, divisions in players_by_sport.items() %}
         <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="pane-{{ sport|lower }}" role="tabpanel">
             <ul class="nav nav-pills mb-3" id="divisionTabs-{{ sport|lower }}" role="tablist">
-                {% for division, players in divisions.items() %}
+                {% for division in division_list %}
                     <li class="nav-item" role="presentation">
                         <button class="nav-link {% if loop.first %}active{% endif %}" id="tab-{{ sport|lower }}-{{ division|replace(' ', '_')|replace('/', '_')|lower }}" data-bs-toggle="pill" data-bs-target="#pane-{{ sport|lower }}-{{ division|replace(' ', '_')|replace('/', '_')|lower }}" type="button" role="tab">
                             {{ division }}
@@ -44,7 +44,8 @@
                 {% endfor %}
             </ul>
             <div class="tab-content">
-                {% for division, players in divisions.items() %}
+                {% for division in division_list %}
+                    {% set players = divisions[division] %}
                     <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="pane-{{ sport|lower }}-{{ division|replace(' ', '_')|replace('/', '_')|lower }}" role="tabpanel">
                         <table class="table table-bordered align-middle">
                             <thead class="table-light">


### PR DESCRIPTION
## Summary
- prepopulate missing divisions for each sport when rendering admin dashboard
- iterate over the full division list so tabs and Add Player rows show even when no players exist

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689109c73270832790033577ca6008e8