### PR TITLE
Expand division handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -121,20 +121,27 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
                 "confirmation_sent": reg.confirmation_sent,
             })
 
-    # Ensure each sport has entries for all divisions, even if no players
+    # Build list of all divisions from defaults and existing data
+    division_names = set(division_order.keys())
+    for divisions in players_by_sport.values():
+        division_names.update(divisions.keys())
+    division_list = sorted(division_names, key=lambda x: division_order.get(x, 999))
+    division_rank = {name: idx for idx, name in enumerate(division_list)}
+
+    # Ensure each sport has entries for every division, even if no players
     for sport in players_by_sport.keys():
-        for division in division_order.keys():
+        for division in division_list:
             players_by_sport[sport].setdefault(division, [])
 
     sorted_players_by_sport = {}
     for sport, divisions in players_by_sport.items():
-        sorted_divisions = dict(sorted(divisions.items(), key=lambda x: division_order.get(x[0], 999)))
+        sorted_divisions = dict(sorted(divisions.items(), key=lambda x: division_rank[x[0]]))
         sorted_players_by_sport[sport] = sorted_divisions
 
     return templates.TemplateResponse("admin.html", {
         "request": request,
         "players_by_sport": sorted_players_by_sport,
-        "division_list": list(division_order.keys()),
+        "division_list": division_list,
         "total_players": len(players),
         "missing_emails": missing_emails,
         "missing_jerseys": missing_jerseys,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -35,6 +35,7 @@
     {% for sport, divisions in players_by_sport.items() %}
         <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="pane-{{ sport|lower }}" role="tabpanel">
             <ul class="nav nav-pills mb-3" id="divisionTabs-{{ sport|lower }}" role="tablist">
+                {# Loop through all divisions, including any custom ones #}
                 {% for division in division_list %}
                     <li class="nav-item" role="presentation">
                         <button class="nav-link {% if loop.first %}active{% endif %}" id="tab-{{ sport|lower }}-{{ division|replace(' ', '_')|replace('/', '_')|lower }}" data-bs-toggle="pill" data-bs-target="#pane-{{ sport|lower }}-{{ division|replace(' ', '_')|replace('/', '_')|lower }}" type="button" role="tab">
@@ -44,6 +45,7 @@
                 {% endfor %}
             </ul>
             <div class="tab-content">
+                {# Render a table for each division in division_list #}
                 {% for division in division_list %}
                     {% set players = divisions[division] %}
                     <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="pane-{{ sport|lower }}-{{ division|replace(' ', '_')|replace('/', '_')|lower }}" role="tabpanel">


### PR DESCRIPTION
## Summary
- Expand division list to include custom divisions discovered among players and sort them consistently.
- Ensure each sport includes empty entries for every division and present them to the admin template.
- Update admin template to iterate over all divisions, including custom ones.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68910c84c5408327a1f21e42cfe066a3