### PR TITLE
Normalize division names in inbound email processing

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -20,6 +20,27 @@ PROMO_CODES = {
     7: "Pines7Players",
 }
 
+# Canonical division definitions and normalization mapping
+DIVISION_ORDER = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
+DIVISION_ALIASES = {
+    "UNDER4": "U4",
+    "UNDER6": "U6",
+    "UNDER8": "U8",
+    "UNDER10": "U10",
+    "UNDER12": "U12",
+    "UNDER14": "U14",
+}
+
+
+def normalize_division(raw: str) -> str:
+    """Map various division strings to canonical form."""
+    key = re.sub(r"[^A-Za-z0-9]", "", raw or "").upper()
+    division = DIVISION_ALIASES.get(key, key)
+    if division not in DIVISION_ORDER:
+        print(f"⚠️ Unknown division '{raw}', defaulting to 'Unknown'")
+        return "Unknown"
+    return division
+
 print("📬 Loaded email.py")
 
 # Simplified for local/dev use – no actual email sending, just update flag
@@ -157,7 +178,7 @@ def process_inbound_email(email_body: str, db):
 
             full_name = name_match.group(1).strip()
             program = program_match.group(1).strip()
-            division = division_match.group(1).strip()
+            division = normalize_division(division_match.group(1).strip())
             parent_email = parent_email_match.group(1).strip()
             order_number = order_number_match.group(1).strip() if order_number_match else None
             order_date = datetime.strptime(order_date_match.group(1).strip(), "%B %d, %Y") if order_date_match else None
@@ -231,6 +252,7 @@ def process_inbound_email(email_body: str, db):
                         else:
                             program = prog_div.strip()
                             division = ""
+                        division = normalize_division(division)
                         parent_email = msg.get("To")
 
                         sport = "unknown"

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -136,3 +136,42 @@ def test_update_division_for_existing_player(db_session):
     reg_updated = db_session.query(Registration).filter_by(player_id=player.id, sport='soccer', season='spring').first()
     assert reg_updated.division == 'U12'
     assert db_session.query(Registration).count() == 1
+
+
+def test_division_normalization(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Normalize'
+    html = """
+    <html><body>
+    Name: Alice Smith<br>
+    Program: Fall Soccer<br>
+    Division: Under 10<br>
+    Parent Email: alice@example.com<br>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    reg = db_session.query(Registration).first()
+    assert reg.division == 'U10'
+
+
+def test_unknown_division_defaults(db_session, capsys):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Unknown'
+    html = """
+    <html><body>
+    Name: Bob Brown<br>
+    Program: Fall Soccer<br>
+    Division: Galactic<br>
+    Parent Email: bob@example.com<br>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+    captured = capsys.readouterr().out
+    assert "Unknown division" in captured
+    reg = db_session.query(Registration).first()
+    assert reg.division == 'Unknown'


### PR DESCRIPTION
## Summary
- normalize division strings from inbound emails using canonical mapping
- handle unknown divisions with explicit logging and "Unknown" fallback
- add tests covering division normalization and unknown cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689118587f7c8327ab33ebbb49bd37b0