### PR TITLE
Add High School division handling

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -21,7 +21,15 @@ PROMO_CODES = {
 }
 
 # Canonical division definitions and normalization mapping
-DIVISION_ORDER = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
+DIVISION_ORDER = {
+    "U4": 0,
+    "U6": 1,
+    "U8": 2,
+    "U10": 3,
+    "U12": 4,
+    "U14": 5,
+    "HS": 6,
+}
 DIVISION_ALIASES = {
     "UNDER4": "U4",
     "UNDER6": "U6",
@@ -29,6 +37,10 @@ DIVISION_ALIASES = {
     "UNDER10": "U10",
     "UNDER12": "U12",
     "UNDER14": "U14",
+    "HIGHSCHOOL": "HS",
+    "HS": "HS",
+    "HIGHSCHOOLBOYS": "HS",
+    "HIGHSCHOOLGIRLS": "HS",
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -97,7 +97,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     except HTTPException as exc:
         return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
     players = db.query(Player).all()
-    division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
+    division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "HS": 6}
     players_by_sport = defaultdict(lambda: defaultdict(list))
     missing_emails = 0
     missing_jerseys = 0

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -157,6 +157,25 @@ def test_division_normalization(db_session):
     assert reg.division == 'U10'
 
 
+def test_high_school_division_normalization(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'NormalizeHS'
+    html = """
+    <html><body>
+    Name: Henry High<br>
+    Program: Fall Soccer<br>
+    Division: High School<br>
+    Parent Email: henry@example.com<br>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    reg = db_session.query(Registration).first()
+    assert reg.division == 'HS'
+
+
 def test_unknown_division_defaults(db_session, capsys):
     msg = MIMEMultipart('alternative')
     msg['Subject'] = 'Unknown'


### PR DESCRIPTION
## Summary
- handle "High School" entries via new `HS` canonical division and aliases
- include High School in division ordering so it sorts after U14
- add tests for High School division normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891298be71c832791e1b2855fd45c57