### PR TITLE
Handle empty divisions and add cleanup script

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -21,7 +21,7 @@ PROMO_CODES = {
 }
 
 # Canonical division definitions and normalization mapping
-DIVISION_ORDER = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
+DIVISION_ORDER = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "High School": 6}
 DIVISION_ALIASES = {
     "UNDER4": "U4",
     "UNDER6": "U6",
@@ -29,6 +29,8 @@ DIVISION_ALIASES = {
     "UNDER10": "U10",
     "UNDER12": "U12",
     "UNDER14": "U14",
+    "HIGHSCHOOL": "High School",
+    "HS": "High School",
 }
 
 
@@ -168,7 +170,6 @@ def process_inbound_email(email_body: str, db):
             missing = [key for key, match in {
                 "Name": name_match,
                 "Program": program_match,
-                "Division": division_match,
                 "Parent Email": parent_email_match,
             }.items() if not match]
 
@@ -178,7 +179,10 @@ def process_inbound_email(email_body: str, db):
 
             full_name = name_match.group(1).strip()
             program = program_match.group(1).strip()
-            division = normalize_division(division_match.group(1).strip())
+            division_raw = division_match.group(1).strip() if division_match else ""
+            division = normalize_division(division_raw)
+            if division == "Unknown" and "high school" in program.lower():
+                division = "High School"
             parent_email = parent_email_match.group(1).strip()
             order_number = order_number_match.group(1).strip() if order_number_match else None
             order_date = datetime.strptime(order_date_match.group(1).strip(), "%B %d, %Y") if order_date_match else None
@@ -253,6 +257,8 @@ def process_inbound_email(email_body: str, db):
                             program = prog_div.strip()
                             division = ""
                         division = normalize_division(division)
+                        if division == "Unknown" and "high school" in program.lower():
+                            division = "High School"
                         parent_email = msg.get("To")
 
                         sport = "unknown"

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,12 @@ from .database import Base, engine, SessionLocal
 from .models import Player, Registration, User
 from .auth import authenticate_user, create_user
 from .services.assign import assign_jersey_number
-from .email import send_confirmation_email, process_inbound_email, save_inbound_email
+from .email import (
+    send_confirmation_email,
+    process_inbound_email,
+    save_inbound_email,
+    normalize_division,
+)
 from collections import defaultdict
 import csv
 import io
@@ -97,7 +102,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     except HTTPException as exc:
         return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
     players = db.query(Player).all()
-    division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
+    division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "High School": 6}
     players_by_sport = defaultdict(lambda: defaultdict(list))
     missing_emails = 0
     missing_jerseys = 0
@@ -124,8 +129,11 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     # Build list of all divisions from defaults and existing data
     division_names = set(division_order.keys())
     for divisions in players_by_sport.values():
-        division_names.update(divisions.keys())
-    division_list = sorted(division_names, key=lambda x: division_order.get(x, 999))
+        division_names.update(div for div in divisions.keys() if div)
+    division_list = sorted(
+        [name for name in division_names if name],
+        key=lambda x: division_order.get(x, 999),
+    )
     division_rank = {name: idx for idx, name in enumerate(division_list)}
 
     # Ensure each sport has entries for every division, even if no players
@@ -170,6 +178,7 @@ def create_player_manual(
 ):
     """Create player and registration from form submission."""
     require_login(request)
+    division = normalize_division(division)
     jersey_number = assign_jersey_number(db, division)
     sport_normalized = sport.strip().lower()
     player = Player(full_name=full_name, parent_email=parent_email, jersey_number=jersey_number)
@@ -233,7 +242,8 @@ def create_player(player: PlayerCreate, request: Request, db: Session = Depends(
 @app.post("/players/inline")
 def create_player_inline(player: InlinePlayerCreate, request: Request, db: Session = Depends(get_db)):
     require_login(request)
-    jersey_number = assign_jersey_number(db, player.division)
+    division = normalize_division(player.division)
+    jersey_number = assign_jersey_number(db, division)
     db_player = Player(
         full_name=player.full_name,
         parent_email=player.parent_email,
@@ -244,7 +254,7 @@ def create_player_inline(player: InlinePlayerCreate, request: Request, db: Sessi
     reg = Registration(
         player_id=db_player.id,
         program=f"{player.season} {player.sport}",
-        division=player.division,
+        division=division,
         sport=player.sport.strip().lower(),
         season=player.season,
     )
@@ -279,8 +289,9 @@ def move_player_division(
     if not reg:
         raise HTTPException(status_code=404, detail="Registration not found")
 
-    reg.division = payload.division
-    reg.player.jersey_number = assign_jersey_number(db, payload.division)
+    new_division = normalize_division(payload.division)
+    reg.division = new_division
+    reg.player.jersey_number = assign_jersey_number(db, new_division)
     db.commit()
     db.refresh(reg)
 

--- a/scripts/add_player.py
+++ b/scripts/add_player.py
@@ -2,6 +2,7 @@ import argparse
 from app.database import SessionLocal
 from app.models import Player, Registration
 from app.services.assign import assign_jersey_number
+from app.email import normalize_division
 
 
 def main():
@@ -15,14 +16,15 @@ def main():
 
     db = SessionLocal()
     try:
-        jersey = assign_jersey_number(db, args.division)
+        division = normalize_division(args.division)
+        jersey = assign_jersey_number(db, division)
         player = Player(full_name=args.full_name, parent_email=args.parent_email, jersey_number=jersey)
         db.add(player)
         db.flush()
         reg = Registration(
             player_id=player.id,
             program=f"{args.season} {args.sport}",
-            division=args.division,
+            division=division,
             sport=args.sport.strip().lower(),
             season=args.season,
         )

--- a/scripts/cleanup_empty_divisions.py
+++ b/scripts/cleanup_empty_divisions.py
@@ -1,0 +1,32 @@
+import argparse
+from app.database import SessionLocal
+from app.models import Registration
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Replace empty division values with canonical names")
+    parser.add_argument("--dry-run", action="store_true", help="Show changes without committing")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        regs = db.query(Registration).filter((Registration.division == "") | (Registration.division.is_(None))).all()
+        updated = 0
+        for reg in regs:
+            prog = (reg.program or "").lower()
+            if "high school" in prog:
+                reg.division = "High School"
+            else:
+                reg.division = "Unknown"
+            updated += 1
+        if args.dry_run:
+            db.rollback()
+        else:
+            db.commit()
+        print(f"Updated {updated} registrations")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -175,3 +175,21 @@ def test_unknown_division_defaults(db_session, capsys):
     assert "Unknown division" in captured
     reg = db_session.query(Registration).first()
     assert reg.division == 'Unknown'
+
+
+def test_missing_division_defaults_to_high_school(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Missing Division'
+    html = """
+    <html><body>
+    Name: Sam Student<br>
+    Program: High School Soccer<br>
+    Parent Email: sam@example.com<br>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    reg = db_session.query(Registration).first()
+    assert reg.division == 'High School'

--- a/tests/test_process_email.py
+++ b/tests/test_process_email.py
@@ -30,7 +30,7 @@ Parent Email: p@example.com
 """
     process_inbound_email(body, db_session)
     captured = capsys.readouterr().out
-    assert "missing: Division" in captured
+    assert "Unknown division" in captured
 
 
 def test_logs_missing_multiple_fields(db_session, capsys):


### PR DESCRIPTION
## Summary
- add High School to canonical division list and map aliases
- normalize and default divisions across manual entry and email parsing
- provide cleanup script for existing registrations with blank divisions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891298dbb2c83278771b7c3b0383c0b