### PR TITLE
Add High School division support and tests

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -21,7 +21,15 @@ PROMO_CODES = {
 }
 
 # Canonical division definitions and normalization mapping
-DIVISION_ORDER = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
+DIVISION_ORDER = {
+    "U4": 0,
+    "U6": 1,
+    "U8": 2,
+    "U10": 3,
+    "U12": 4,
+    "U14": 5,
+    "High School": 6,
+}
 DIVISION_ALIASES = {
     "UNDER4": "U4",
     "UNDER6": "U6",
@@ -29,6 +37,8 @@ DIVISION_ALIASES = {
     "UNDER10": "U10",
     "UNDER12": "U12",
     "UNDER14": "U14",
+    "HIGHSCHOOL": "High School",
+    "HS": "High School",
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -97,7 +97,15 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     except HTTPException as exc:
         return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
     players = db.query(Player).all()
-    division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5}
+    division_order = {
+        "U4": 0,
+        "U6": 1,
+        "U8": 2,
+        "U10": 3,
+        "U12": 4,
+        "U14": 5,
+        "High School": 6,
+    }
     players_by_sport = defaultdict(lambda: defaultdict(list))
     missing_emails = 0
     missing_jerseys = 0

--- a/tests/test_high_school_division.py
+++ b/tests/test_high_school_division.py
@@ -1,0 +1,92 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from starlette.requests import Request
+
+# Ensure database URL is set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from app.database import Base
+from app.models import Player, Registration
+from app.services.assign import assign_jersey_number
+from app.email import process_inbound_email
+from app.main import admin_dashboard
+
+import pytest
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_manual_high_school_registration(db_session):
+    jersey = assign_jersey_number(db_session, 'High School')
+    player = Player(full_name='HS Player', parent_email='parent@example.com', jersey_number=jersey)
+    db_session.add(player)
+    db_session.flush()
+    reg = Registration(
+        player_id=player.id,
+        program='Fall Soccer',
+        division='High School',
+        sport='soccer',
+        season='fall',
+    )
+    db_session.add(reg)
+    db_session.commit()
+
+    stored = db_session.query(Registration).filter_by(player_id=player.id).first()
+    assert stored.division == 'High School'
+    assert player.jersey_number == 1
+
+
+def test_email_high_school_normalization(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Test HS'
+    html = """
+    <html><body>
+    Name: John HS<br>
+    Program: Fall Soccer<br>
+    Division: High School<br>
+    Parent Email: parent@example.com<br>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    reg = db_session.query(Registration).first()
+    assert reg.division == 'High School'
+    player = db_session.query(Player).first()
+    assert player.jersey_number == 1
+
+
+def test_admin_shows_high_school(db_session):
+    jersey = assign_jersey_number(db_session, 'High School')
+    player = Player(full_name='Admin HS', parent_email='admin@example.com', jersey_number=jersey)
+    db_session.add(player)
+    db_session.flush()
+    reg = Registration(
+        player_id=player.id,
+        program='Fall Soccer',
+        division='High School',
+        sport='soccer',
+        season='fall',
+    )
+    db_session.add(reg)
+    db_session.commit()
+
+    req = Request({'type': 'http', 'session': {'user_id': 1}})
+    response = admin_dashboard(req, db_session)
+    divisions = response.context['division_list']
+    assert 'High School' in divisions
+    assert '' not in divisions


### PR DESCRIPTION
## Summary
- handle High School division in normalization and admin sorting
- test manual High School registration, email parsing, and admin view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891298e7cec8327b9e8cf4bc8e2c700