### PR TITLE
Exclude blank and custom divisions from admin dashboard

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -21,9 +21,6 @@ PROMO_CODES = {
 }
 
 # Canonical division definitions and normalization mapping
-codex/validate-and-clean-division-values
-DIVISION_ORDER = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "High School": 6}
-=======
 DIVISION_ORDER = {
     "U4": 0,
     "U6": 1,
@@ -33,7 +30,6 @@ DIVISION_ORDER = {
     "U14": 5,
     "High School": 6,
 }
-main
 DIVISION_ALIASES = {
     "UNDER4": "U4",
     "UNDER6": "U6",

--- a/app/main.py
+++ b/app/main.py
@@ -102,9 +102,6 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     except HTTPException as exc:
         return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
     players = db.query(Player).all()
-codex/validate-and-clean-division-values
-    division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "High School": 6}
-
     division_order = {
         "U4": 0,
         "U6": 1,
@@ -114,7 +111,7 @@ codex/validate-and-clean-division-values
         "U14": 5,
         "High School": 6,
     }
-main
+    EXCLUDED_DIVISIONS = {"", "Pend O'reille Pines (High School Club Team)"}
     players_by_sport = defaultdict(lambda: defaultdict(list))
     missing_emails = 0
     missing_jerseys = 0
@@ -127,23 +124,29 @@ main
 
         for reg in player.registrations:
             sport_key = (reg.sport or "").strip().lower()
-            players_by_sport[sport_key][reg.division].append({
+            division = (reg.division or "").strip()
+            if division in EXCLUDED_DIVISIONS:
+                continue
+            players_by_sport[sport_key][division].append({
                 "id": player.id,
                 "registration_id": reg.id,
                 "full_name": player.full_name,
                 "parent_email": player.parent_email,
                 "jersey_number": player.jersey_number,
                 "sport": sport_key,
-                "division": reg.division,
+                "division": division,
                 "confirmation_sent": reg.confirmation_sent,
             })
 
     # Build list of all divisions from defaults and existing data
     division_names = set(division_order.keys())
     for divisions in players_by_sport.values():
-        division_names.update(div for div in divisions.keys() if div)
+        for div in divisions.keys():
+            name = (div or "").strip()
+            if name not in EXCLUDED_DIVISIONS:
+                division_names.add(name)
     division_list = sorted(
-        [name for name in division_names if name],
+        division_names,
         key=lambda x: division_order.get(x, 999),
     )
     division_rank = {name: idx for idx, name in enumerate(division_list)}

--- a/tests/test_high_school_division.py
+++ b/tests/test_high_school_division.py
@@ -83,6 +83,31 @@ def test_admin_shows_high_school(db_session):
         season='fall',
     )
     db_session.add(reg)
+
+    # Add entries that should be excluded
+    blank_player = Player(full_name='Blank', parent_email='blank@example.com', jersey_number=assign_jersey_number(db_session, ''))
+    db_session.add(blank_player)
+    db_session.flush()
+    blank_reg = Registration(
+        player_id=blank_player.id,
+        program='Fall Soccer',
+        division='',
+        sport='soccer',
+        season='fall',
+    )
+    db_session.add(blank_reg)
+
+    custom_player = Player(full_name='Custom', parent_email='custom@example.com', jersey_number=assign_jersey_number(db_session, "Pend O'reille Pines (High School Club Team)"))
+    db_session.add(custom_player)
+    db_session.flush()
+    custom_reg = Registration(
+        player_id=custom_player.id,
+        program='Fall Soccer',
+        division="Pend O'reille Pines (High School Club Team)",
+        sport='soccer',
+        season='fall',
+    )
+    db_session.add(custom_reg)
     db_session.commit()
 
     req = Request({'type': 'http', 'session': {'user_id': 1}})
@@ -90,3 +115,4 @@ def test_admin_shows_high_school(db_session):
     divisions = response.context['division_list']
     assert 'High School' in divisions
     assert '' not in divisions
+    assert "Pend O'reille Pines (High School Club Team)" not in divisions


### PR DESCRIPTION
## Summary
- filter out blank and "Pend O'reille Pines (High School Club Team)" divisions in admin dashboard
- clean up email module's division constants
- ensure admin dashboard test verifies excluded divisions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891317c31b083278b0cfd411e4ff374