### PR TITLE
Add alias for Pend Oreille HS club team

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -21,9 +21,6 @@ PROMO_CODES = {
 }
 
 # Canonical division definitions and normalization mapping
-codex/validate-and-clean-division-values
-DIVISION_ORDER = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "High School": 6}
-=======
 DIVISION_ORDER = {
     "U4": 0,
     "U6": 1,
@@ -33,7 +30,6 @@ DIVISION_ORDER = {
     "U14": 5,
     "High School": 6,
 }
-main
 DIVISION_ALIASES = {
     "UNDER4": "U4",
     "UNDER6": "U6",
@@ -43,12 +39,13 @@ DIVISION_ALIASES = {
     "UNDER14": "U14",
     "HIGHSCHOOL": "High School",
     "HS": "High School",
+    "PENDOREILLEPINESHIGHSCHOOLCLUBTEAM": "High School",
 }
 
 
 def normalize_division(raw: str) -> str:
     """Map various division strings to canonical form."""
-    key = re.sub(r"[^A-Za-z0-9]", "", raw or "").upper()
+    key = re.sub(r"[^A-Za-z0-9]", "", (raw or "").strip()).upper()
     division = DIVISION_ALIASES.get(key, key)
     if division not in DIVISION_ORDER:
         print(f"⚠️ Unknown division '{raw}', defaulting to 'Unknown'")

--- a/app/main.py
+++ b/app/main.py
@@ -102,9 +102,6 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     except HTTPException as exc:
         return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
     players = db.query(Player).all()
-codex/validate-and-clean-division-values
-    division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "High School": 6}
-
     division_order = {
         "U4": 0,
         "U6": 1,
@@ -114,7 +111,6 @@ codex/validate-and-clean-division-values
         "U14": 5,
         "High School": 6,
     }
-main
     players_by_sport = defaultdict(lambda: defaultdict(list))
     missing_emails = 0
     missing_jerseys = 0

--- a/tests/test_high_school_division.py
+++ b/tests/test_high_school_division.py
@@ -90,3 +90,24 @@ def test_admin_shows_high_school(db_session):
     divisions = response.context['division_list']
     assert 'High School' in divisions
     assert '' not in divisions
+
+
+def test_pend_oreille_alias(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Pend Oreille Test'
+    html = """
+    <html><body>
+    Name: Alias HS<br>
+    Program: Fall Soccer<br>
+    Division: Pend Oreille Pines High School Club Team<br>
+    Parent Email: parent@example.com<br>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    reg = db_session.query(Registration).first()
+    assert reg.division == 'High School'
+    divisions = {d for (d,) in db_session.query(Registration.division).distinct()}
+    assert divisions == {'High School'}


### PR DESCRIPTION
## Summary
- map `PENDOREILLEPINESHIGHSCHOOLCLUBTEAM` to `High School`
- trim whitespace in division normalization
- test that Pend Oreille club team divisions normalize to High School

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891317c910483279f9750649b92430d