### PR TITLE
Clean division order definitions

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -21,9 +21,6 @@ PROMO_CODES = {
 }
 
 # Canonical division definitions and normalization mapping
-codex/validate-and-clean-division-values
-DIVISION_ORDER = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "High School": 6}
-=======
 DIVISION_ORDER = {
     "U4": 0,
     "U6": 1,
@@ -33,7 +30,6 @@ DIVISION_ORDER = {
     "U14": 5,
     "High School": 6,
 }
-main
 DIVISION_ALIASES = {
     "UNDER4": "U4",
     "UNDER6": "U6",

--- a/app/main.py
+++ b/app/main.py
@@ -102,9 +102,6 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     except HTTPException as exc:
         return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
     players = db.query(Player).all()
-codex/validate-and-clean-division-values
-    division_order = {"U4": 0, "U6": 1, "U8": 2, "U10": 3, "U12": 4, "U14": 5, "High School": 6}
-
     division_order = {
         "U4": 0,
         "U6": 1,
@@ -114,7 +111,6 @@ codex/validate-and-clean-division-values
         "U14": 5,
         "High School": 6,
     }
-main
     players_by_sport = defaultdict(lambda: defaultdict(list))
     missing_emails = 0
     missing_jerseys = 0


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers around `DIVISION_ORDER` and `division_order`

## Testing
- `python -m py_compile app/email.py app/main.py`
- `python - <<'PY'
import os
os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
import app.email
import app.main
print('modules imported successfully')
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891317d48ac8327bbaca2c322dc1f34