### PR TITLE
fix: remove stray lines causing syntax error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -111,10 +111,8 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
         "U14": 5,
         "High School": 6,
     }
-codex/remove-unnecessary-lines-from-email.py-and-main.py
 
     EXCLUDED_DIVISIONS = {"", "Pend O'reille Pines (High School Club Team)"}
-main
     players_by_sport = defaultdict(lambda: defaultdict(list))
     missing_emails = 0
     missing_jerseys = 0


### PR DESCRIPTION
## Summary
- remove stray debug lines from `admin_dashboard` for correct syntax

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68913f1d5c4c8327ba05d1afdbb6c7cf