### PR TITLE
Refine division handling and support Pines HS club team

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+__pycache__/
+*.pyc

--- a/app/email.py
+++ b/app/email.py
@@ -29,6 +29,7 @@ DIVISION_ORDER = {
     "U12": 4,
     "U14": 5,
     "High School": 6,
+    "Pend Oreille Pines (High School Club Team)": 7,
 }
 DIVISION_ALIASES = {
     "UNDER4": "U4",
@@ -39,6 +40,7 @@ DIVISION_ALIASES = {
     "UNDER14": "U14",
     "HIGHSCHOOL": "High School",
     "HS": "High School",
+    "PENDOREILLEPINESHIGHSCHOOLCLUBTEAM": "Pend Oreille Pines (High School Club Team)",
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -110,10 +110,11 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
         "U12": 4,
         "U14": 5,
         "High School": 6,
+        "Pend Oreille Pines (High School Club Team)": 7,
     }
-
-    EXCLUDED_DIVISIONS = {"", "Pend O'reille Pines (High School Club Team)"}
+    EXCLUDED_DIVISIONS = {"", "Unknown"}
     players_by_sport = defaultdict(lambda: defaultdict(list))
+    unassigned_by_sport = defaultdict(list)
     missing_emails = 0
     missing_jerseys = 0
 
@@ -125,8 +126,19 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
 
         for reg in player.registrations:
             sport_key = (reg.sport or "").strip().lower()
-            division = (reg.division or "").strip()
+            division_raw = (reg.division or "").strip()
+            division = normalize_division(division_raw) if division_raw else ""
             if division in EXCLUDED_DIVISIONS:
+                unassigned_by_sport[sport_key].append({
+                    "id": player.id,
+                    "registration_id": reg.id,
+                    "full_name": player.full_name,
+                    "parent_email": player.parent_email,
+                    "jersey_number": player.jersey_number,
+                    "sport": sport_key,
+                    "division": division,
+                    "confirmation_sent": reg.confirmation_sent,
+                })
                 continue
             players_by_sport[sport_key][division].append({
                 "id": player.id,
@@ -166,6 +178,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
         "request": request,
         "players_by_sport": sorted_players_by_sport,
         "division_list": division_list,
+        "unassigned_players_by_sport": unassigned_by_sport,
         "total_players": len(players),
         "missing_emails": missing_emails,
         "missing_jerseys": missing_jerseys,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -43,6 +43,13 @@
                         </button>
                     </li>
                 {% endfor %}
+                {% if unassigned_players_by_sport[sport] %}
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="tab-{{ sport|lower }}-unassigned" data-bs-toggle="pill" data-bs-target="#pane-{{ sport|lower }}-unassigned" type="button" role="tab">
+                            Unassigned
+                        </button>
+                    </li>
+                {% endif %}
             </ul>
             <div class="tab-content">
                 {# Render a table for each division in division_list #}
@@ -101,6 +108,61 @@
                         </table>
                     </div>
                 {% endfor %}
+                {% if unassigned_players_by_sport[sport] %}
+                    {% set players = unassigned_players_by_sport[sport] %}
+                    <div class="tab-pane fade" id="pane-{{ sport|lower }}-unassigned" role="tabpanel">
+                        <table class="table table-bordered align-middle">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Jersey #</th>
+                                    <th>Parent Email</th>
+                                    <th>Email Sent</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody data-sport="{{ sport|lower }}" data-division="">
+                                {% for player in players %}
+                                    <tr data-player-id="{{ player.id }}" data-reg-id="{{ player.registration_id }}">
+                                        <td><span class="full-name">{{ player.full_name }}</span><input class="form-control d-none edit-full-name" value="{{ player.full_name }}"></td>
+                                        <td><span class="jersey-number">{{ player.jersey_number }}</span><input class="form-control d-none edit-jersey-number" type="number" value="{{ player.jersey_number }}"></td>
+                                        <td><span class="parent-email">{{ player.parent_email }}</span><input class="form-control d-none edit-parent-email" value="{{ player.parent_email }}"></td>
+                                        <td class="email-status">
+                                            {% if player.confirmation_sent %}
+                                                ✅
+                                            {% else %}
+                                                ❌
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            <button class="btn btn-sm btn-primary btn-edit">Edit</button>
+                                            <button class="btn btn-sm btn-success btn-save d-none">Save</button>
+                                            <button class="btn btn-sm btn-secondary btn-cancel d-none">Cancel</button>
+                                            <button class="btn btn-sm btn-info btn-send-email">Email</button>
+                                            <button class="btn btn-sm btn-warning btn-move">Move</button>
+                                            <button class="btn btn-sm btn-danger btn-delete">Delete</button>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                                <tr class="add-row">
+                                    <td colspan="5">
+                                        <button class="btn btn-sm btn-primary btn-show-add-form">Add Player</button>
+                                    </td>
+                                </tr>
+                                <tr class="add-form-row d-none">
+                                    <td><input class="form-control new-full-name" placeholder="Full Name"></td>
+                                    <td>-</td>
+                                    <td><input class="form-control new-parent-email" placeholder="Parent Email"></td>
+                                    <td></td>
+                                    <td>
+                                        <button class="btn btn-sm btn-success btn-add-save">Save</button>
+                                        <button class="btn btn-sm btn-secondary btn-add-cancel">Cancel</button>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
             </div>
         </div>
     {% endfor %}

--- a/tests/test_divisions.py
+++ b/tests/test_divisions.py
@@ -1,0 +1,98 @@
+import os
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Ensure DATABASE_URL set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from fastapi.testclient import TestClient
+import app.main as app_main
+from app.main import app, Base, get_db
+from app.models import Player, Registration
+from app.email import normalize_division
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    # bypass authentication and startup logic
+    app_main.require_login = lambda request: None
+    app.router.on_startup.clear()
+
+    with TestClient(app) as c:
+        c.SessionLocal = TestingSessionLocal
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def setup_players_unassigned(SessionLocal):
+    db = SessionLocal()
+    p1 = Player(full_name='Assigned', parent_email='a@example.com', jersey_number=1)
+    db.add(p1)
+    db.flush()
+    db.add(Registration(player_id=p1.id, program='prog', division='U8', sport='soccer', season='2024'))
+    p2 = Player(full_name='Blank', parent_email='b@example.com', jersey_number=2)
+    db.add(p2)
+    db.flush()
+    db.add(Registration(player_id=p2.id, program='prog', division='', sport='soccer', season='2024'))
+    p3 = Player(full_name='Mystery', parent_email='c@example.com', jersey_number=3)
+    db.add(p3)
+    db.flush()
+    db.add(Registration(player_id=p3.id, program='prog', division='Unknown', sport='soccer', season='2024'))
+    db.commit()
+    db.close()
+
+
+def setup_player(SessionLocal):
+    db = SessionLocal()
+    p1 = Player(full_name='Player1', parent_email='p1@example.com', jersey_number=4)
+    db.add(p1)
+    db.flush()
+    reg = Registration(player_id=p1.id, program='prog', division='U8', sport='soccer', season='2024')
+    db.add(reg)
+    db.commit()
+    reg_id = reg.id
+    db.close()
+    return reg_id
+
+
+def test_normalize_pend_oreille():
+    assert normalize_division('Pend Oreille Pines (High School Club Team)') == 'Pend Oreille Pines (High School Club Team)'
+
+
+def test_admin_unassigned_tab(client):
+    setup_players_unassigned(client.SessionLocal)
+    response = client.get('/admin')
+    assert response.status_code == 200
+    text = response.text
+    assert 'Unassigned' in text
+    assert 'Unknown' not in text
+    assert 'Blank' in text
+    assert 'Mystery' in text
+    assert 'Pend Oreille Pines (High School Club Team)' in text
+
+
+def test_move_player_to_pines_division(client):
+    reg_id = setup_player(client.SessionLocal)
+    response = client.put(f'/registrations/{reg_id}/division', json={'division': 'Pend Oreille Pines (High School Club Team)'})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['division'] == 'Pend Oreille Pines (High School Club Team)'
+    db = client.SessionLocal()
+    reg = db.query(Registration).get(reg_id)
+    assert reg.division == 'Pend Oreille Pines (High School Club Team)'
+    db.close()


### PR DESCRIPTION
## Summary
- Hide players with blank or unknown divisions from main tabs and show them under a new Unassigned tab
- Support the "Pend Oreille Pines (High School Club Team)" division across normalization, sorting, and admin reassignment
- Test division normalization, unassigned tab display, and moving a player into the new club team division

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689141413c5c8327b6a6a05f41667767