### PR TITLE
Filter admin players by current season

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ import csv
 import io
 import os
 
+CURRENT_SEASON = os.getenv("CURRENT_SEASON", "2024")
 app = FastAPI()
 app.add_middleware(SessionMiddleware, secret_key=os.getenv("SECRET_KEY", "secret-key"))
 templates = Jinja2Templates(directory="app/templates")
@@ -101,7 +102,13 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
         require_login(request)
     except HTTPException as exc:
         return RedirectResponse(exc.headers["Location"], status_code=exc.status_code)
-    players = db.query(Player).all()
+    players = (
+        db.query(Player)
+            .join(Player.registrations)
+            .filter(Registration.season == CURRENT_SEASON)
+            .distinct()
+            .all()
+    )
     division_order = {
         "U4": 0,
         "U6": 1,

--- a/tests/test_admin_player_count.py
+++ b/tests/test_admin_player_count.py
@@ -1,0 +1,58 @@
+import os
+import re
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Ensure DATABASE_URL and CURRENT_SEASON set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['CURRENT_SEASON'] = '2024'
+
+from fastapi.testclient import TestClient
+import app.main as app_main
+from app.main import app, Base, get_db
+from app.models import Player, Registration
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    # bypass authentication and startup logic
+    app_main.require_login = lambda request: None
+    app.router.on_startup.clear()
+
+    with TestClient(app) as c:
+        c.SessionLocal = TestingSessionLocal
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def test_admin_player_count(client):
+    db = client.SessionLocal()
+    p1 = Player(full_name='Registered', parent_email='r@example.com', jersey_number=1)
+    db.add(p1)
+    db.flush()
+    db.add(Registration(player_id=p1.id, program='prog', division='U8', sport='soccer', season='2024'))
+    p2 = Player(full_name='Unregistered', parent_email='u@example.com', jersey_number=2)
+    db.add(p2)
+    db.commit()
+    db.close()
+
+    response = client.get('/admin')
+    assert response.status_code == 200
+    match = re.search(r'fs-4 fw-bold text-dark">(\d+)</div>\s*<small class="text-muted">Total Athletes</small>', response.text)
+    assert match is not None
+    assert match.group(1) == '1'


### PR DESCRIPTION
## Summary
- Restrict admin player list to active season registrations using `CURRENT_SEASON`
- Count total players based on filtered query
- Add regression test ensuring unregistered players aren't counted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689145b286488327b6ee862c0b54d74f