### PR TITLE
Fix total player count in admin dashboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -131,6 +131,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
     unassigned_by_sport = defaultdict(list)
     missing_emails = 0
     missing_jerseys = 0
+    counted_player_ids = set()
 
     for player in players:
         if not player.parent_email:
@@ -154,6 +155,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
                     "confirmation_sent": reg.confirmation_sent,
                 })
                 continue
+            counted_player_ids.add(player.id)
             players_by_sport[sport_key][division].append({
                 "id": player.id,
                 "registration_id": reg.id,
@@ -193,7 +195,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
         "players_by_sport": sorted_players_by_sport,
         "division_list": division_list,
         "unassigned_players_by_sport": unassigned_by_sport,
-        "total_players": len(players),
+        "total_players": len(counted_player_ids),
         "missing_emails": missing_emails,
         "missing_jerseys": missing_jerseys,
     })

--- a/tests/test_admin_player_count.py
+++ b/tests/test_admin_player_count.py
@@ -56,3 +56,35 @@ def test_admin_player_count(client):
     match = re.search(r'fs-4 fw-bold text-dark">(\d+)</div>\s*<small class="text-muted">Total Athletes</small>', response.text)
     assert match is not None
     assert match.group(1) == '1'
+
+
+def test_admin_excludes_unassigned_divisions(client):
+    db = client.SessionLocal()
+    # Player with valid division
+    p_valid = Player(full_name='Valid', parent_email='v@example.com', jersey_number=1)
+    db.add(p_valid)
+    db.flush()
+    db.add(Registration(player_id=p_valid.id, program='prog', division='U8', sport='soccer', season='2024'))
+
+    # Player with only excluded division
+    p_blank = Player(full_name='Blank', parent_email='b@example.com', jersey_number=2)
+    db.add(p_blank)
+    db.flush()
+    db.add(Registration(player_id=p_blank.id, program='prog', division='', sport='soccer', season='2024'))
+
+    # Player with mixed divisions (one excluded, one valid)
+    p_mixed = Player(full_name='Mixed', parent_email='m@example.com', jersey_number=3)
+    db.add(p_mixed)
+    db.flush()
+    db.add(Registration(player_id=p_mixed.id, program='prog', division='Unknown', sport='basketball', season='2024'))
+    db.add(Registration(player_id=p_mixed.id, program='prog', division='U10', sport='soccer', season='2024'))
+
+    db.commit()
+    db.close()
+
+    response = client.get('/admin')
+    assert response.status_code == 200
+    match = re.search(r'fs-4 fw-bold text-dark">(\d+)</div>\s*<small class="text-muted">Total Athletes</small>', response.text)
+    assert match is not None
+    # Only p_valid and p_mixed should be counted
+    assert match.group(1) == '2'


### PR DESCRIPTION
## Summary
- track unique player IDs for valid registrations in admin dashboard
- compute total player count from these IDs
- test exclusion of unassigned divisions from total

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689149fba65c8327876c0744002bf1f6