### PR TITLE
Group multiple registrations into one confirmation email

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -56,12 +56,18 @@ def normalize_division(raw: str) -> str:
 print("📬 Loaded email.py")
 
 # Simplified for local/dev use – no actual email sending, just update flag
-def send_confirmation_email(to_email, player_name, jersey_number, order_url, registration=None, db=None, promo_code=None):
+def send_confirmation_email(to_email, players, order_url, registrations=None, db=None, promo_code=None):
     promo_msg = f" Promo code: {promo_code}" if promo_code else ""
-    print(f"[DEV MODE] Skipping sending email to {to_email} for {player_name} (#{jersey_number}){promo_msg}")
+    player_list = ", ".join(
+        f"{p['name']} (#{p['jersey_number']})" for p in players
+    )
+    print(
+        f"[DEV MODE] Skipping sending email to {to_email} for {player_list}{promo_msg}"
+    )
 
-    if registration and db:
-        registration.confirmation_sent = True
+    if registrations and db:
+        for reg in registrations:
+            reg.confirmation_sent = True
         db.commit()
 
 # Optional: uncomment to send actual emails in production
@@ -340,10 +346,9 @@ def process_inbound_email(email_body: str, db):
             # Auto email sending disabled. Uncomment to enable.
             # send_confirmation_email(
             #     player.parent_email,
-            #     player.full_name,
-            #     player.jersey_number,
+            #     [{"name": player.full_name, "jersey_number": player.jersey_number}],
             #     "https://your-order-url.com",
-            #     reg,
+            #     [reg],
             #     db,
             #     promo_code=promo_code,
             # )

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from .email import (
     process_inbound_email,
     save_inbound_email,
     normalize_division,
+    PROMO_CODES,
 )
 from collections import defaultdict
 import csv
@@ -393,13 +394,27 @@ def send_registration_email(registration_id: int, request: Request, db: Session 
     reg = db.query(Registration).get(registration_id)
     if not reg:
         raise HTTPException(status_code=404, detail="Registration not found")
-    player = reg.player
+    parent_email = reg.player.parent_email
+    regs = (
+        db.query(Registration)
+        .join(Registration.player)
+        .filter(
+            Player.parent_email == parent_email,
+            Registration.confirmation_sent == False,
+        )
+        .all()
+    )
+    players = [
+        {"name": r.player.full_name, "jersey_number": r.player.jersey_number}
+        for r in regs
+    ]
+    promo_code = PROMO_CODES.get(len(regs))
     send_confirmation_email(
-        player.parent_email,
-        player.full_name,
-        player.jersey_number,
+        parent_email,
+        players,
         "https://your-order-url.com",
-        reg,
+        regs,
         db,
+        promo_code=promo_code,
     )
     return {"message": "Email sent"}

--- a/tests/test_group_email.py
+++ b/tests/test_group_email.py
@@ -1,0 +1,78 @@
+import os
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Ensure DATABASE_URL and CURRENT_SEASON set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['CURRENT_SEASON'] = '2024'
+
+from fastapi.testclient import TestClient
+import app.main as app_main
+from app.main import app, Base, get_db
+from app.models import Player, Registration
+from app.email import PROMO_CODES
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    # bypass authentication and startup logic
+    app_main.require_login = lambda request: None
+    app.router.on_startup.clear()
+
+    with TestClient(app) as c:
+        c.SessionLocal = TestingSessionLocal
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def test_group_registration_email(client, monkeypatch):
+    db = client.SessionLocal()
+    p1 = Player(full_name='Alex', parent_email='parent@example.com', jersey_number=12)
+    p2 = Player(full_name='Jamie', parent_email='parent@example.com', jersey_number=34)
+    db.add_all([p1, p2])
+    db.flush()
+    r1 = Registration(player_id=p1.id, program='prog', division='U8', sport='soccer', season='2024', confirmation_sent=False)
+    r2 = Registration(player_id=p2.id, program='prog', division='U10', sport='soccer', season='2024', confirmation_sent=False)
+    db.add_all([r1, r2])
+    db.commit()
+    r1_id, r2_id = r1.id, r2.id
+    db.close()
+
+    captured = {}
+
+    def fake_send_confirmation_email(to_email, players, order_url, registrations=None, db=None, promo_code=None):
+        captured['to_email'] = to_email
+        captured['players'] = players
+        captured['promo_code'] = promo_code
+        if registrations and db:
+            for reg in registrations:
+                reg.confirmation_sent = True
+            db.commit()
+
+    monkeypatch.setattr(app_main, 'send_confirmation_email', fake_send_confirmation_email)
+
+    response = client.post(f'/registrations/{r1_id}/send_email')
+    assert response.status_code == 200
+    assert captured['to_email'] == 'parent@example.com'
+    assert len(captured['players']) == 2
+    assert captured['promo_code'] == PROMO_CODES.get(2)
+
+    db = client.SessionLocal()
+    assert db.query(Registration).get(r1_id).confirmation_sent
+    assert db.query(Registration).get(r2_id).confirmation_sent
+    db.close()


### PR DESCRIPTION
## Summary
- Allow confirmation emails to bundle multiple players in one message
- Auto-select promo code based on grouped registrations
- Add test ensuring grouped emails mark all registrations as sent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689159b2400c8327a497e178fd981ed2