### PR TITLE
feat: send combined jersey emails

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -56,28 +56,75 @@ def normalize_division(raw: str) -> str:
 print("📬 Loaded email.py")
 
 # Simplified for local/dev use – no actual email sending, just update flag
-def send_confirmation_email(to_email, player_name, jersey_number, order_url, registration=None, db=None, promo_code=None):
-    promo_msg = f" Promo code: {promo_code}" if promo_code else ""
-    print(f"[DEV MODE] Skipping sending email to {to_email} for {player_name} (#{jersey_number}){promo_msg}")
+def send_confirmation_email(
+    to_email, players, order_url, registrations=None, db=None, promo_code=None
+):
+    """Send a confirmation email listing all players and their jersey numbers.
 
-    if registration and db:
-        registration.confirmation_sent = True
+    In development, this simply logs the email body. When used in production
+    (see commented block below), the same body is provided to SendGrid.
+    """
+
+    intro = (
+        "Hello POSA family,\n\n"
+        "Thank you for registering with Pend Oreille Sports Association. "
+        "Below are the jersey numbers for your players:\n\n"
+    )
+
+    lines = [intro]
+    for player in players:
+        lines.append(player["name"])
+        lines.append(f"Jersey Number: {player['jersey_number']}")
+        if promo_code:
+            lines.append(f"Promo Code: {promo_code}")
+        lines.append("")
+
+    lines.append(
+        "Please keep this email for your records. You can order uniforms at the "
+        "link below.\n"
+    )
+    lines.append(order_url)
+    lines.append("")
+    lines.append("Thank you for supporting POSA!")
+
+    body = "\n".join(lines)
+
+    print(f"[DEV MODE] Skipping sending email to {to_email} with body:\n{body}")
+
+    if registrations and db:
+        for reg in registrations:
+            reg.confirmation_sent = True
         db.commit()
 
 # Optional: uncomment to send actual emails in production
-# def send_confirmation_email(to_email, player_name, jersey_number, order_url, registration=None, db=None, promo_code=None):
-#     html = f"""
-#         <p>Hi {player_name},</p>
-#         <p>Your jersey number is <strong>{jersey_number}</strong>.</p>
-#     """
-#     if promo_code:
-#         html += f"<p>Your promo code is <strong>{promo_code}</strong>. Use it during checkout for your free jersey.</p>"
-#     html += f'<p>You can order your uniform here: <a href="{order_url}">Order Jersey</a></p>'
+# def send_confirmation_email(
+#     to_email, players, order_url, registrations=None, db=None, promo_code=None
+# ):
+#     intro = (
+#         "Hello POSA family,\n\n"
+#         "Thank you for registering with Pend Oreille Sports Association. "
+#         "Below are the jersey numbers for your players:\n\n"
+#     )
+#     lines = [intro]
+#     for player in players:
+#         lines.append(player["name"])
+#         lines.append(f"Jersey Number: {player['jersey_number']}")
+#         if promo_code:
+#             lines.append(f"Promo Code: {promo_code}")
+#         lines.append("")
+#     lines.append(
+#         "Please keep this email for your records. You can order uniforms at the "
+#         "link below.\n"
+#     )
+#     lines.append(order_url)
+#     lines.append("")
+#     lines.append("Thank you for supporting POSA!")
+#     body = "\n".join(lines)
 #     message = Mail(
 #         from_email="noreply@posasports.org",
 #         to_emails=to_email,
-#         subject="Your POSA Jersey Number",
-#         html_content=html,
+#         subject="Your POSA Jersey Numbers",
+#         plain_text_content=body,
 #     )
 #     try:
 #         sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
@@ -85,8 +132,9 @@ def send_confirmation_email(to_email, player_name, jersey_number, order_url, reg
 #         print(response.status_code)
 #         print(response.body)
 #         print(response.headers)
-#         if registration and db:
-#             registration.confirmation_sent = True
+#         if registrations and db:
+#             for reg in registrations:
+#                 reg.confirmation_sent = True
 #             db.commit()
 #     except Exception as e:
 #         print(e)

--- a/app/main.py
+++ b/app/main.py
@@ -396,10 +396,9 @@ def send_registration_email(registration_id: int, request: Request, db: Session 
     player = reg.player
     send_confirmation_email(
         player.parent_email,
-        player.full_name,
-        player.jersey_number,
+        [{"name": player.full_name, "jersey_number": player.jersey_number}],
         "https://your-order-url.com",
-        reg,
-        db,
+        registrations=[reg],
+        db=db,
     )
     return {"message": "Email sent"}

--- a/tests/test_send_confirmation_email.py
+++ b/tests/test_send_confirmation_email.py
@@ -1,0 +1,59 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure DATABASE_URL is set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from app.database import Base
+from app.email import send_confirmation_email
+from app.models import Player, Registration
+
+import pytest
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_email_body_lists_all_players(db_session, capsys):
+    player1 = Player(full_name='Alice', parent_email='parent@example.com', jersey_number=5)
+    player2 = Player(full_name='Bob', parent_email='parent@example.com', jersey_number=7)
+    db_session.add_all([player1, player2])
+    db_session.flush()
+
+    reg1 = Registration(player_id=player1.id, program='Prog', division='U8', sport='soccer', season='2024')
+    reg2 = Registration(player_id=player2.id, program='Prog', division='U8', sport='soccer', season='2024')
+    db_session.add_all([reg1, reg2])
+    db_session.commit()
+
+    players = [
+        {"name": player1.full_name, "jersey_number": player1.jersey_number},
+        {"name": player2.full_name, "jersey_number": player2.jersey_number},
+    ]
+
+    send_confirmation_email(
+        'parent@example.com',
+        players,
+        'http://order.example.com',
+        registrations=[reg1, reg2],
+        db=db_session,
+        promo_code='CODE123',
+    )
+
+    captured = capsys.readouterr().out
+    # Both players appear in the single logged email
+    assert 'Alice' in captured
+    assert 'Bob' in captured
+    # Promo code appears for each player
+    assert captured.count('Promo Code: CODE123') == 2
+    # Registrations were marked as sent
+    assert reg1.confirmation_sent and reg2.confirmation_sent


### PR DESCRIPTION
## Summary
- consolidate confirmation emails so one message lists all players, jersey numbers, and promo codes
- update admin endpoint to use new send_confirmation_email signature
- add regression test for combined confirmation email flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68917092f11483278f5e49418bac17b4