### PR TITLE
Compose detailed confirmation email

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -56,21 +56,32 @@ def normalize_division(raw: str) -> str:
 print("📬 Loaded email.py")
 
 # Simplified for local/dev use – no actual email sending, just update flag
-def send_confirmation_email(
-    to_email, players, order_url, registrations=None, db=None, promo_code=None
-):
-    body_parts = []
+def send_confirmation_email(to_email, players, registrations=None, db=None):
+    body = (
+        "Thanks for signing up for soccer with the Pend Oreille Pines. We're excited to have your family with us this season!\n\n"
+        "Here's the jersey info for your player(s):\n\n"
+    )
+
     for p in players:
-        block = (
+        body += (
             f"{p['name']}\n"
             f"Jersey Number: {p['jersey_number']}\n"
-            f"Order Jersey: {order_url}\n"
+            f"Promo Code: {p['promo_code']}\n\n"
         )
-        if promo_code:
-            block += f"Promo Code: {promo_code}\n"
-        body_parts.append(block)
 
-    body = "\n".join(body_parts).strip()
+    body += (
+        "Order your jerseys here:\n"
+        "https://treblemade.com/search?q=pines&sort_by=relevance\n\n"
+        "Only the reversible Pines jersey is required for games. You're welcome to add Pines-branded black shorts and socks to your order, or use your own. Any plain black shorts and socks are just fine as long as they don't have other team logos or colors.\n\n"
+        "If your family is in a position to purchase the jerseys without using the promo codes, it helps us stretch our nonprofit funds to support other families and improve the program. But either way, jerseys are covered and we're thrilled to have your kids on the field.\n\n"
+        "—\n"
+        "Tim Chilcott\n"
+        "President - POSA\n"
+        "🌲 Pines stand tall.\n"
+        "❤️ The heart of sports starts with us."
+    )
+
+    body = body.strip()
 
     message = Mail(
         from_email="noreply@posasports.org",

--- a/app/main.py
+++ b/app/main.py
@@ -404,17 +404,14 @@ def send_registration_email(registration_id: int, request: Request, db: Session 
         )
         .all()
     )
+    promo_code = PROMO_CODES.get(len(regs))
     players = [
-        {"name": r.player.full_name, "jersey_number": r.player.jersey_number}
+        {
+            "name": r.player.full_name,
+            "jersey_number": r.player.jersey_number,
+            "promo_code": promo_code,
+        }
         for r in regs
     ]
-    promo_code = PROMO_CODES.get(len(regs))
-    send_confirmation_email(
-        parent_email,
-        players,
-        "https://treblemade.com/search?q=pines&sort_by=relevance",
-        regs,
-        db,
-        promo_code=promo_code,
-    )
+    send_confirmation_email(parent_email, players, regs, db)
     return {"message": "Email sent"}

--- a/tests/test_group_email.py
+++ b/tests/test_group_email.py
@@ -55,10 +55,9 @@ def test_group_registration_email(client, monkeypatch):
 
     captured = {}
 
-    def fake_send_confirmation_email(to_email, players, order_url, registrations=None, db=None, promo_code=None):
+    def fake_send_confirmation_email(to_email, players, registrations=None, db=None):
         captured['to_email'] = to_email
         captured['players'] = players
-        captured['promo_code'] = promo_code
         if registrations and db:
             for reg in registrations:
                 reg.confirmation_sent = True
@@ -70,7 +69,8 @@ def test_group_registration_email(client, monkeypatch):
     assert response.status_code == 200
     assert captured['to_email'] == 'parent@example.com'
     assert len(captured['players']) == 2
-    assert captured['promo_code'] == PROMO_CODES.get(2)
+    expected = PROMO_CODES.get(2)
+    assert {p['promo_code'] for p in captured['players']} == {expected}
 
     db = client.SessionLocal()
     assert db.query(Registration).get(r1_id).confirmation_sent
@@ -78,12 +78,11 @@ def test_group_registration_email(client, monkeypatch):
     db.close()
 
 def _mock_email(monkeypatch, captured):
-    def fake_send_confirmation_email(to_email, players, order_url, registrations=None, db=None, promo_code=None):
-        body = "\n".join(f"{p['name']} (#{p['jersey_number']})" for p in players)
-        if promo_code:
-            body += f"\n{promo_code}"
+    def fake_send_confirmation_email(to_email, players, registrations=None, db=None):
+        body = "\n".join(
+            f"{p['name']} (#{p['jersey_number']}) {p['promo_code']}" for p in players
+        )
         captured['body'] = body
-        captured['promo_code'] = promo_code
         if registrations and db:
             for reg in registrations:
                 reg.confirmation_sent = True
@@ -109,12 +108,10 @@ def test_single_player_email_body(client, monkeypatch):
     assert response.status_code == 200
 
     body_lines = captured['body'].splitlines()
-    promo = captured['promo_code']
-    player_lines = [line for line in body_lines if line != promo]
-    assert len(player_lines) == 1
-    assert 'Solo' in player_lines[0]
-    assert promo == PROMO_CODES.get(1)
-    assert captured['body'].count(promo) == 1
+    promo = PROMO_CODES.get(1)
+    assert len(body_lines) == 1
+    assert 'Solo' in body_lines[0]
+    assert promo in body_lines[0]
 
     db = client.SessionLocal()
     assert db.query(Registration).get(reg_id).confirmation_sent
@@ -143,13 +140,12 @@ def test_three_player_email_body(client, monkeypatch):
     assert response.status_code == 200
 
     body_lines = captured['body'].splitlines()
-    promo = captured['promo_code']
-    player_lines = [line for line in body_lines if line != promo]
-    assert len(player_lines) == 3
+    promo = PROMO_CODES.get(3)
+    assert len(body_lines) == 3
     for name in names:
-        assert any(name in line for line in player_lines)
-    assert promo == PROMO_CODES.get(3)
-    assert captured['body'].count(promo) == 1
+        assert any(name in line for line in body_lines)
+    for line in body_lines:
+        assert promo in line
 
     db = client.SessionLocal()
     for rid in reg_ids:


### PR DESCRIPTION
## Summary
- render per-player jersey details with promo codes and hardcoded order link in confirmation emails
- pass promo codes with each player and streamline call site
- update group email tests for per-player codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68917a6113f08327814711c8c107192f