### PR TITLE
Include player details in confirmation emails

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -63,7 +63,7 @@ def send_confirmation_email(to_email, players, registrations=None, db=None):
     """Send a registration confirmation email with jersey info."""
 
     players_html = "\n".join(
-        f"<p>{p['name']}<br>Jersey Number: {p['jersey_number']}<br>Promo Code: {p.get('promo_code', '')}</p>"
+        f"<p>Player: {p['name']} (#{p['jersey_number']})<br>Promo Code: {p.get('promo_code', '')}</p>"
         for p in players
     )
 

--- a/tests/test_group_email.py
+++ b/tests/test_group_email.py
@@ -71,6 +71,7 @@ def test_group_registration_email(client, monkeypatch):
     assert len(captured['players']) == 2
     expected = PROMO_CODES.get(2)
     assert {p['promo_code'] for p in captured['players']} == {expected}
+    assert {p['jersey_number'] for p in captured['players']} == {12, 34}
 
     db = client.SessionLocal()
     assert db.query(Registration).get(r1_id).confirmation_sent
@@ -112,6 +113,7 @@ def test_single_player_email_body(client, monkeypatch):
     assert len(body_lines) == 1
     assert 'Solo' in body_lines[0]
     assert promo in body_lines[0]
+    assert '#7' in body_lines[0]
 
     db = client.SessionLocal()
     assert db.query(Registration).get(reg_id).confirmation_sent
@@ -146,6 +148,8 @@ def test_three_player_email_body(client, monkeypatch):
         assert any(name in line for line in body_lines)
     for line in body_lines:
         assert promo in line
+    for num in [10, 20, 30]:
+        assert any(f'#{num}' in line for line in body_lines)
 
     db = client.SessionLocal()
     for rid in reg_ids:


### PR DESCRIPTION
## Summary
- Ensure confirmation emails list each player's name and jersey number
- Validate jersey numbers are included in email content through tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68918f988fd883279fd13c8bd6dd8849