### PR TITLE
Allow resending registration email regardless of confirmation status

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -398,10 +398,7 @@ def send_registration_email(registration_id: int, request: Request, db: Session 
     regs = (
         db.query(Registration)
         .join(Registration.player)
-        .filter(
-            Player.parent_email == parent_email,
-            Registration.confirmation_sent == False,
-        )
+        .filter(Player.parent_email == parent_email)
         .all()
     )
     promo_code = PROMO_CODES.get(len(regs))


### PR DESCRIPTION
## Summary
- Expand registration query to include all registrations for a parent, enabling manual resends even after confirmation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68921a95b78c832798f99257f5e41e2e