### PR TITLE
Handle high school team emails separately with plain text fallback

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -58,18 +58,25 @@ def normalize_division(raw: str) -> str:
 print("📬 Loaded email.py")
 
 
-def send_confirmation_email(to_email, players, registrations=None, db=None):
-    """Send a registration confirmation email with jersey info."""
+def _plain_text_from_html(html: str) -> str:
+    """Derive a plain-text version of HTML content."""
+    return BeautifulSoup(html, "html.parser").get_text("\n")
+
+
+def send_confirmation_email(to_email, players, promo_code=None, registrations=None, db=None):
+    """Send a registration confirmation email with jersey info for standard divisions."""
 
     players_html = "\n".join(
-        f"<p>Player: {p['name']} (#{p['jersey_number']})<br>Promo Code: {p.get('promo_code', '')}</p>"
-        for p in players
+        f"<p>Player: {p['name']} (#{p['jersey_number']})</p>" for p in players
     )
+
+    promo_html = f"<p>Promo Code: {promo_code}</p>" if promo_code else ""
 
     html = (
         "<p>Thanks for signing up for soccer with the Pend Oreille Pines. We’re excited to have your family with us this season!</p>"
         "<p>Here’s the jersey info for your player(s):</p>"
         f"{players_html}"
+        f"{promo_html}"
         f"<p>Order your jerseys here:<br><a href=\"{UNIFORM_ORDER_URL}\">{UNIFORM_ORDER_URL}</a></p>"
         "<p>Only the reversible Pines jersey is required for games. You’re welcome to add Pines-branded black shorts and socks to your order, or use your own. Any plain black shorts and socks are just fine as long as they don’t have other team logos or colors.</p>"
         "<p>If your family is in a position to purchase the jerseys without using the promo codes, it helps us stretch our nonprofit funds to support other families and improve the program. But either way, jerseys are covered and we’re thrilled to have your kids on the field.</p>"
@@ -79,11 +86,52 @@ def send_confirmation_email(to_email, players, registrations=None, db=None):
     message = Mail(
         from_email="noreply@posasports.org",
         to_emails=to_email,
-        subject="Your POSA Jersey Numbers",
+        subject="Jersey Numbers and Uniform Info for Your Player(s)",
         html_content=html,
+        plain_text_content=_plain_text_from_html(html),
     )
     # Email sending disabled for production.
     # The following block can be reinstated to re-enable SendGrid emails:
+    # try:
+    #     sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
+    #     response = sg.send(message)
+    #     print(response.status_code)
+    #     print(response.body)
+    #     print(response.headers)
+    #     if registrations and db and 200 <= response.status_code < 300:
+    #         for reg in registrations:
+    #             reg.confirmation_sent = True
+    #         db.commit()
+    # except Exception as e:
+    #     print(e)
+    print("✉️ Email sending is currently disabled.")
+
+
+def send_pines_confirmation_email(to_email, players, registrations=None, db=None):
+    """Send a registration confirmation email for Pend Oreille Pines High School Club Team."""
+
+    players_html = "\n".join(
+        f"<p>{p['name']}<br>Jersey Number: {p['jersey_number']}</p>" for p in players
+    )
+
+    html = (
+        "<p>Thanks for registering with the Pend Oreille Pines High School Club Team. We’re looking forward to a strong season ahead.</p>"
+        "<p>Here’s the jersey info for your player(s):</p>"
+        f"{players_html}"
+        f"<p>Order your full kit here:<br><a href=\"{UNIFORM_ORDER_URL}\">{UNIFORM_ORDER_URL}</a></p>"
+        "<p><strong>Uniform Requirements:</strong><br>All High School Club Team players are required to wear the full Pines kit:<br>• Reversible Pines jersey<br>• Pines black shorts<br>• Pines black socks</p>"
+        "<p>Please complete your order as soon as possible to ensure everything arrives before the first match. Promo codes are not used for this team, as club players are responsible for purchasing their full kits.</p>"
+        "<p>—<br>Tim Chilcott<br>President - POSA<br>🌲 Pines stand tall.<br>❤️ The heart of sports starts with us.</p>"
+    )
+
+    message = Mail(
+        from_email="noreply@posasports.org",
+        to_emails=to_email,
+        subject="Jersey Numbers and Uniform Info for Your Player(s)",
+        html_content=html,
+        plain_text_content=_plain_text_from_html(html),
+    )
+    # Email sending disabled for production.
     # try:
     #     sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
     #     response = sg.send(message)

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from .auth import authenticate_user, create_user
 from .services.assign import assign_jersey_number
 from .email import (
     send_confirmation_email,
+    send_pines_confirmation_email,
     process_inbound_email,
     save_inbound_email,
     normalize_division,
@@ -398,14 +399,23 @@ def send_registration_email(registration_id: int, request: Request, db: Session 
         .filter(Player.parent_email == parent_email)
         .all()
     )
-    promo_code = PROMO_CODES.get(len(regs))
-    players = [
-        {
-            "name": r.player.full_name,
-            "jersey_number": r.player.jersey_number,
-            "promo_code": promo_code,
-        }
-        for r in regs
-    ]
-    send_confirmation_email(parent_email, players, regs, db)
+    pines_division = "Pend Oreille Pines (High School Club Team)"
+    regular_regs = [r for r in regs if r.division != pines_division]
+    pines_regs = [r for r in regs if r.division == pines_division]
+
+    if regular_regs:
+        promo_code = PROMO_CODES.get(len(regular_regs))
+        players = [
+            {"name": r.player.full_name, "jersey_number": r.player.jersey_number}
+            for r in regular_regs
+        ]
+        send_confirmation_email(parent_email, players, promo_code, regular_regs, db)
+
+    if pines_regs:
+        players = [
+            {"name": r.player.full_name, "jersey_number": r.player.jersey_number}
+            for r in pines_regs
+        ]
+        send_pines_confirmation_email(parent_email, players, pines_regs, db)
+
     return {"message": "Email sent"}

--- a/tests/test_group_email.py
+++ b/tests/test_group_email.py
@@ -55,9 +55,10 @@ def test_group_registration_email(client, monkeypatch):
 
     captured = {}
 
-    def fake_send_confirmation_email(to_email, players, registrations=None, db=None):
+    def fake_send_confirmation_email(to_email, players, promo_code=None, registrations=None, db=None):
         captured['to_email'] = to_email
         captured['players'] = players
+        captured['promo_code'] = promo_code
         if registrations and db:
             for reg in registrations:
                 reg.confirmation_sent = True
@@ -70,7 +71,7 @@ def test_group_registration_email(client, monkeypatch):
     assert captured['to_email'] == 'parent@example.com'
     assert len(captured['players']) == 2
     expected = PROMO_CODES.get(2)
-    assert {p['promo_code'] for p in captured['players']} == {expected}
+    assert captured['promo_code'] == expected
     assert {p['jersey_number'] for p in captured['players']} == {12, 34}
 
     db = client.SessionLocal()
@@ -79,15 +80,16 @@ def test_group_registration_email(client, monkeypatch):
     db.close()
 
 def _mock_email(monkeypatch, captured):
-    def fake_send_confirmation_email(to_email, players, registrations=None, db=None):
-        body = "\n".join(
-            f"{p['name']} (#{p['jersey_number']}) {p['promo_code']}" for p in players
-        )
-        captured['body'] = body
+    def fake_send_confirmation_email(to_email, players, promo_code=None, registrations=None, db=None):
+        lines = [f"{p['name']} (#{p['jersey_number']})" for p in players]
+        if promo_code:
+            lines.append(promo_code)
+        captured['body'] = "\n".join(lines)
         if registrations and db:
             for reg in registrations:
                 reg.confirmation_sent = True
             db.commit()
+
     monkeypatch.setattr(app_main, 'send_confirmation_email', fake_send_confirmation_email)
 
 
@@ -110,10 +112,10 @@ def test_single_player_email_body(client, monkeypatch):
 
     body_lines = captured['body'].splitlines()
     promo = PROMO_CODES.get(1)
-    assert len(body_lines) == 1
+    assert len(body_lines) == 2
     assert 'Solo' in body_lines[0]
-    assert promo in body_lines[0]
     assert '#7' in body_lines[0]
+    assert body_lines[1] == promo
 
     db = client.SessionLocal()
     assert db.query(Registration).get(reg_id).confirmation_sent
@@ -143,13 +145,12 @@ def test_three_player_email_body(client, monkeypatch):
 
     body_lines = captured['body'].splitlines()
     promo = PROMO_CODES.get(3)
-    assert len(body_lines) == 3
+    assert len(body_lines) == 4
     for name in names:
-        assert any(name in line for line in body_lines)
-    for line in body_lines:
-        assert promo in line
+        assert any(name in line for line in body_lines[:-1])
+    assert body_lines[-1] == promo
     for num in [10, 20, 30]:
-        assert any(f'#{num}' in line for line in body_lines)
+        assert any(f'#{num}' in line for line in body_lines[:-1])
 
     db = client.SessionLocal()
     for rid in reg_ids:

--- a/tests/test_high_school_email.py
+++ b/tests/test_high_school_email.py
@@ -1,0 +1,125 @@
+import os
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Ensure DATABASE_URL and CURRENT_SEASON set before importing application modules
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['CURRENT_SEASON'] = '2024'
+
+from fastapi.testclient import TestClient
+import app.main as app_main
+from app.main import app, Base, get_db
+from app.models import Player, Registration
+from app.email import PROMO_CODES
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app_main.require_login = lambda request: None
+    app.router.on_startup.clear()
+
+    with TestClient(app) as c:
+        c.SessionLocal = TestingSessionLocal
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def test_high_school_email_no_promo(client, monkeypatch):
+    db = client.SessionLocal()
+    p = Player(full_name='HS Player', parent_email='parent@example.com', jersey_number=9)
+    db.add(p)
+    db.flush()
+    r = Registration(player_id=p.id, program='prog', division='Pend Oreille Pines (High School Club Team)', sport='soccer', season='2024', confirmation_sent=False)
+    db.add(r)
+    db.commit()
+    reg_id = r.id
+    db.close()
+
+    captured = {}
+
+    def fake_pines_email(to_email, players, registrations=None, db=None):
+        captured['to_email'] = to_email
+        captured['players'] = players
+        if registrations and db:
+            for reg in registrations:
+                reg.confirmation_sent = True
+            db.commit()
+
+    monkeypatch.setattr(app_main, 'send_pines_confirmation_email', fake_pines_email)
+    # ensure standard email not called
+    monkeypatch.setattr(app_main, 'send_confirmation_email', lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('standard email should not be sent')))
+
+    response = client.post(f'/registrations/{reg_id}/send_email')
+    assert response.status_code == 200
+    assert captured['to_email'] == 'parent@example.com'
+    assert len(captured['players']) == 1
+    assert 'promo_code' not in captured['players'][0]
+
+    db = client.SessionLocal()
+    assert db.query(Registration).get(reg_id).confirmation_sent
+    db.close()
+
+
+def test_mixed_family_two_emails(client, monkeypatch):
+    db = client.SessionLocal()
+    # regular player
+    p_reg = Player(full_name='Youth', parent_email='parent@example.com', jersey_number=10)
+    # high school player
+    p_hs = Player(full_name='HS', parent_email='parent@example.com', jersey_number=1)
+    db.add_all([p_reg, p_hs])
+    db.flush()
+    r_reg = Registration(player_id=p_reg.id, program='prog', division='U10', sport='soccer', season='2024', confirmation_sent=False)
+    r_hs = Registration(player_id=p_hs.id, program='prog', division='Pend Oreille Pines (High School Club Team)', sport='soccer', season='2024', confirmation_sent=False)
+    db.add_all([r_reg, r_hs])
+    db.commit()
+    r_reg_id, r_hs_id = r_reg.id, r_hs.id
+    db.close()
+
+    captured = {'standard': None, 'pines': None}
+
+    def fake_standard_email(to_email, players, promo_code=None, registrations=None, db=None):
+        captured['standard'] = {'to_email': to_email, 'players': players, 'promo_code': promo_code}
+        if registrations and db:
+            for reg in registrations:
+                reg.confirmation_sent = True
+            db.commit()
+
+    def fake_pines_email(to_email, players, registrations=None, db=None):
+        captured['pines'] = {'to_email': to_email, 'players': players}
+        if registrations and db:
+            for reg in registrations:
+                reg.confirmation_sent = True
+            db.commit()
+
+    monkeypatch.setattr(app_main, 'send_confirmation_email', fake_standard_email)
+    monkeypatch.setattr(app_main, 'send_pines_confirmation_email', fake_pines_email)
+
+    response = client.post(f'/registrations/{r_reg_id}/send_email')
+    assert response.status_code == 200
+    assert captured['standard'] is not None
+    assert captured['pines'] is not None
+
+    assert captured['standard']['promo_code'] == PROMO_CODES.get(1)
+    assert len(captured['standard']['players']) == 1
+    assert len(captured['pines']['players']) == 1
+    assert 'promo_code' not in captured['pines']['players'][0]
+
+    db = client.SessionLocal()
+    assert db.query(Registration).get(r_reg_id).confirmation_sent
+    assert db.query(Registration).get(r_hs_id).confirmation_sent
+    db.close()


### PR DESCRIPTION
## Summary
- send standard confirmation emails with a single promo code and plain-text fallback
- add dedicated Pend Oreille Pines High School Club Team template with uniform requirements and no promo code
- group parent registrations by division so high school emails send separately

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c880b3848327bda28c845a87762b