### PR TITLE
CC Tim on outbound emails

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -23,6 +23,9 @@ PROMO_CODES = {
 # URL for ordering uniforms
 UNIFORM_ORDER_URL = "https://treblemade.com/search?q=pines&sort_by=relevance"
 
+# Address that should be CC'd on all outbound emails
+DEFAULT_CC_EMAIL = "tim@posasports.org"
+
 # Canonical division definitions and normalization mapping
 DIVISION_ORDER = {
     "U4": 0,
@@ -90,6 +93,7 @@ def send_confirmation_email(to_email, players, promo_code=None, registrations=No
         html_content=html,
         plain_text_content=_plain_text_from_html(html),
     )
+    message.add_cc(DEFAULT_CC_EMAIL)
     try:
         sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
         response = sg.send(message)
@@ -128,6 +132,7 @@ def send_pines_confirmation_email(to_email, players, registrations=None, db=None
         html_content=html,
         plain_text_content=_plain_text_from_html(html),
     )
+    message.add_cc(DEFAULT_CC_EMAIL)
     try:
         sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
         response = sg.send(message)

--- a/tests/test_email_cc.py
+++ b/tests/test_email_cc.py
@@ -1,0 +1,38 @@
+from app import email
+
+
+def _capture_email(monkeypatch):
+    sent = {}
+
+    class FakeSendGridClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def send(self, message):
+            sent['message'] = message
+            class Response:
+                status_code = 202
+                body = ''
+                headers = {}
+            return Response()
+
+    monkeypatch.setattr(email, "SendGridAPIClient", FakeSendGridClient)
+    return sent
+
+
+def test_confirmation_email_cc(monkeypatch):
+    sent = _capture_email(monkeypatch)
+    email.send_confirmation_email(
+        "user@example.com", [{"name": "Alice", "jersey_number": 5}]
+    )
+    cc_list = sent['message'].get()['personalizations'][0]['cc']
+    assert any(addr['email'] == 'tim@posasports.org' for addr in cc_list)
+
+
+def test_pines_confirmation_email_cc(monkeypatch):
+    sent = _capture_email(monkeypatch)
+    email.send_pines_confirmation_email(
+        "user@example.com", [{"name": "Bob", "jersey_number": 7}]
+    )
+    cc_list = sent['message'].get()['personalizations'][0]['cc']
+    assert any(addr['email'] == 'tim@posasports.org' for addr in cc_list)


### PR DESCRIPTION
## Summary
- Add `DEFAULT_CC_EMAIL` constant and CC Tim on every outbound email.
- Test that standard and high-school email senders include Tim in the CC list.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892e7e046088327b523c7175c277e4c