### PR TITLE
Avoid duplicate CC in confirmation emails

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -93,7 +93,8 @@ def send_confirmation_email(to_email, players, promo_code=None, registrations=No
         html_content=html,
         plain_text_content=_plain_text_from_html(html),
     )
-    message.add_cc(DEFAULT_CC_EMAIL)
+    if to_email != DEFAULT_CC_EMAIL:
+        message.add_cc(DEFAULT_CC_EMAIL)
     try:
         sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
         response = sg.send(message)
@@ -132,7 +133,8 @@ def send_pines_confirmation_email(to_email, players, registrations=None, db=None
         html_content=html,
         plain_text_content=_plain_text_from_html(html),
     )
-    message.add_cc(DEFAULT_CC_EMAIL)
+    if to_email != DEFAULT_CC_EMAIL:
+        message.add_cc(DEFAULT_CC_EMAIL)
     try:
         sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
         response = sg.send(message)


### PR DESCRIPTION
## Summary
- Skip adding default CC if recipient is the default address

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892f0214efc832797b026d1d93463ca