### PR TITLE
Fix player parsing from order table rows

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -318,11 +318,26 @@ def process_inbound_email(email_body: str, db):
                     if len(spans) >= 2:
                         full_name = spans[0].get_text(strip=True)
                         prog_div = spans[1].get_text(strip=True)
+
+                        # Skip rows that don't look like player entries
+                        if not prog_div:
+                            continue
+                        if re.search(r"Order (Date|Number)", full_name, re.IGNORECASE):
+                            continue
+                        # Detect date-like strings in the name column
+                        date_pattern = r"(?:\d{1,2}/\d{1,2}/\d{2,4}|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\s+\d{1,2},\s+\d{4})"
+                        if re.search(date_pattern, full_name, re.IGNORECASE):
+                            continue
+
                         if " - " in prog_div:
                             program, division = [p.strip() for p in prog_div.split(" - ", 1)]
                         else:
                             program = prog_div.strip()
                             division = ""
+
+                        if not full_name or not program:
+                            continue
+
                         division = normalize_division(division)
                         if division == "Unknown" and "high school" in program.lower():
                             division = "Pend Oreille Pines (High School Club Team)"

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -77,6 +77,31 @@ def test_order_details_table_parsing(db_session):
     assert len(regs) == 2
     assert all(r.order_number == 'ABC123' for r in regs)
     assert all(r.order_date.date() == datetime(2024, 1, 2).date() for r in regs)
+
+
+def test_order_date_row_skipped(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg['To'] = 'parent@example.com'
+    html = """
+    <html><body>
+    <table>
+        <tr><td>Order Details</td></tr>
+        <tr><td><span>Order Date</span></td><td><span>January 2, 2024</span></td></tr>
+        <tr><td><span>John Doe</span></td><td><span>Fall Soccer - U10</span></td></tr>
+    </table>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    players = db_session.query(Player).all()
+    assert len(players) == 1
+    assert players[0].full_name == 'John Doe'
+
+    regs = db_session.query(Registration).all()
+    assert len(regs) == 1
 def test_bluesombrero_fixture_parsing(db_session):
     fixture = os.path.join('tests', 'fixtures', 'bluesombrero_order.html')
     with open(fixture, 'r') as f:


### PR DESCRIPTION
## Summary
- Validate span contents when parsing order details tables to avoid treating metadata rows as players
- Add regression test ensuring "Order Date" rows are skipped

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893973e0c6c832782c0a712a535107b