### PR TITLE
test: skip timestamp rows in email parsing

### DIFF
--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -10,7 +10,7 @@ os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
 
 from app.database import Base
 from app.models import Player, Registration
-from app.email import process_inbound_email
+from app.email import process_inbound_email, PROMO_CODES
 from datetime import datetime
 
 import pytest
@@ -102,6 +102,35 @@ def test_order_date_row_skipped(db_session):
 
     regs = db_session.query(Registration).all()
     assert len(regs) == 1
+
+
+def test_timestamp_row_skipped(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg['To'] = 'parent@example.com'
+    html = """
+    <html><body>
+    <table>
+        <tr><td>Order Details</td></tr>
+        <tr><td><span>Aug 05, 2025 12:29 PM</span><span>Fall Soccer - U10</span></td></tr>
+        <tr><td><span>John Doe</span></td><td><span>Fall Soccer - U10</span></td></tr>
+    </table>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    players = db_session.query(Player).all()
+    assert len(players) == 1
+    assert players[0].full_name == 'John Doe'
+
+    regs = db_session.query(Registration).all()
+    assert len(regs) == 1
+    promo_code = PROMO_CODES.get(len(regs))
+    assert promo_code == PROMO_CODES.get(1)
+
+
 def test_bluesombrero_fixture_parsing(db_session):
     fixture = os.path.join('tests', 'fixtures', 'bluesombrero_order.html')
     with open(fixture, 'r') as f:


### PR DESCRIPTION
## Summary
- ensure parser imports promo codes for testing
- verify rows with timestamps instead of names are ignored

## Testing
- `pytest tests/test_email_parser.py::test_timestamp_row_skipped -q`


------
https://chatgpt.com/codex/tasks/task_e_68939f8ed624832787daa499280f9f2a