### PR TITLE
Add test for timestamp span handling in email parser

### DIFF
--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -161,6 +161,38 @@ def test_timestamp_span_removed(db_session):
     assert regs[0].division == 'U10'
 
 
+def test_order_details_row_three_spans(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg['To'] = 'parent@example.com'
+    html = """
+    <html><body>
+    <table>
+        <tr><td>Order Details</td></tr>
+        <tr><td><span>Aug 05, 2025 12:29 PM</span><span>John Doe</span><span>Fall Soccer - U10</span></td></tr>
+    </table>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    players = db_session.query(Player).all()
+    assert len(players) == 1
+    assert players[0].full_name == 'John Doe'
+    assert (
+        db_session.query(Player)
+        .filter_by(full_name='Aug 05, 2025 12:29 PM')
+        .first()
+        is None
+    )
+
+    regs = db_session.query(Registration).all()
+    assert len(regs) == 1
+    assert regs[0].program == 'Fall Soccer'
+    assert regs[0].division == 'U10'
+
+
 def test_bluesombrero_fixture_parsing(db_session):
     fixture = os.path.join('tests', 'fixtures', 'bluesombrero_order.html')
     with open(fixture, 'r') as f:


### PR DESCRIPTION
## Summary
- add regression test ensuring a row with timestamp/name/program spans is parsed into a single player and timestamp is ignored

## Testing
- `pytest tests/test_email_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a46093b08327ab59896f6a3ea8a2