### PR TITLE
Handle price spans with extra content

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -327,9 +327,12 @@ def process_inbound_email(email_body: str, db):
                     ):
                         texts.pop(0)
 
-                    # Skip rows where first span looks like a price or non-name token
-                    price_pattern = r"^\$?\d+(?:\.\d{2})?$"
-                    if texts and re.match(price_pattern, texts[0]):
+                    # Skip rows where the first span looks like a price or lacks letters
+                    currency_pattern = r"^\$?[\d,]+(?:\.\d{2})?(?:\s*[:A-Za-z].*)?$"
+                    if texts and (
+                        re.match(currency_pattern, texts[0])
+                        or not re.search(r"[A-Za-z]", texts[0])
+                    ):
                         continue
 
                     if len(texts) < 2:

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -223,6 +223,36 @@ def test_price_row_skipped_and_promo_code(db_session):
     assert promo_code == PROMO_CODES.get(2)
 
 
+def test_price_span_with_extra_content_skipped(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg['To'] = 'parent@example.com'
+    html = """
+    <html><body>
+    <table>
+        <tr><td>Order Details</td></tr>
+        <tr><td>Order Number</td><td>ABC123</td></tr>
+        <tr><td>Order Date</td><td>January 2, 2024</td></tr>
+        <tr><td><span>$50.00</span><span>Maverick West</span></td><td><span>Fall Soccer - U10</span></td></tr>
+        <tr><td><span>John Doe</span></td><td><span>Fall Soccer - U10</span></td></tr>
+        <tr><td><span>Jane Smith</span></td><td><span>Fall Soccer - U8</span></td></tr>
+    </table>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    players = db_session.query(Player).order_by(Player.full_name).all()
+    assert [p.full_name for p in players] == ['Jane Smith', 'John Doe']
+    assert db_session.query(Player).filter_by(full_name='Maverick West').first() is None
+
+    regs = db_session.query(Registration).order_by(Registration.division).all()
+    assert len(regs) == 2
+    promo_code = PROMO_CODES.get(len(regs))
+    assert promo_code == PROMO_CODES.get(2)
+
+
 def test_bluesombrero_fixture_parsing(db_session):
     fixture = os.path.join('tests', 'fixtures', 'bluesombrero_order.html')
     with open(fixture, 'r') as f:


### PR DESCRIPTION
## Summary
- Skip order table rows when first span looks like a currency amount or lacks letters to avoid parsing prices as players.
- Add regression test for rows where price spans share a cell with extra content ensuring promo codes count only valid players.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689413bf94f8832788dddffc5b1691e5