### PR TITLE
Normalize divisions when sending Pines emails

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -400,8 +400,15 @@ def send_registration_email(registration_id: int, request: Request, db: Session 
         .all()
     )
     pines_division = "Pend Oreille Pines (High School Club Team)"
-    regular_regs = [r for r in regs if r.division != pines_division]
-    pines_regs = [r for r in regs if r.division == pines_division]
+
+    regular_regs = []
+    pines_regs = []
+    for r in regs:
+        division = normalize_division(r.division)
+        if division == pines_division:
+            pines_regs.append(r)
+        else:
+            regular_regs.append(r)
 
     if regular_regs:
         promo_code = PROMO_CODES.get(len(regular_regs))

--- a/tests/test_high_school_email.py
+++ b/tests/test_high_school_email.py
@@ -50,6 +50,19 @@ def test_high_school_email_no_promo(client, monkeypatch):
     reg_id = r.id
     db.close()
 
+
+def test_high_school_alias_uses_pines_email(client, monkeypatch):
+    db = client.SessionLocal()
+    p = Player(full_name='HS Player', parent_email='parent@example.com', jersey_number=9)
+    db.add(p)
+    db.flush()
+    # Use alias division that should normalize to the Pines division
+    r = Registration(player_id=p.id, program='prog', division='High School', sport='soccer', season='2024', confirmation_sent=False)
+    db.add(r)
+    db.commit()
+    reg_id = r.id
+    db.close()
+
     captured = {}
 
     def fake_pines_email(to_email, players, registrations=None, db=None):


### PR DESCRIPTION
## Summary
- Normalize each registration's division before splitting into regular and Pines groups
- Add regression test ensuring a 'High School' alias triggers Pines email without promo code

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894dffb3eb88327a875efc1fe5bb383