### PR TITLE
Handle split jersey number spans

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -327,8 +327,12 @@ def process_inbound_email(email_body: str, db):
                     ):
                         texts.pop(0)
 
-                    # Remove any leading "Jersey Number" spans
+                    # Remove any leading "Jersey Number" spans and following numeric value
+                    jersey_label_removed = False
                     while texts and texts[0].lower().startswith("jersey number"):
+                        texts.pop(0)
+                        jersey_label_removed = True
+                    if jersey_label_removed and texts and re.match(r"^\d+$", texts[0]):
                         texts.pop(0)
 
                     # Skip rows where the first span looks like a price or lacks letters

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -225,6 +225,36 @@ def test_jersey_number_span_removed(db_session):
     assert regs[0].division == 'U10'
 
 
+def test_jersey_number_split_span_removed(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg['To'] = 'parent@example.com'
+    html = """
+    <html><body>
+    <table>
+        <tr><td>Order Details</td></tr>
+        <tr>
+            <td><span>Aug 05, 2025 12:29 PM</span><span>Jersey Number:</span><span>7</span><span>John Doe</span></td>
+            <td><span>Fall Soccer - U10</span></td>
+        </tr>
+    </table>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    players = db_session.query(Player).all()
+    assert len(players) == 1
+    assert players[0].full_name == 'John Doe'
+    assert db_session.query(Player).filter_by(full_name='7').first() is None
+
+    regs = db_session.query(Registration).all()
+    assert len(regs) == 1
+    assert regs[0].program == 'Fall Soccer'
+    assert regs[0].division == 'U10'
+
+
 def test_price_row_skipped_and_promo_code(db_session):
     msg = MIMEMultipart('alternative')
     msg['Subject'] = 'Order'


### PR DESCRIPTION
## Summary
- Strip numeric jersey spans following "Jersey Number" labels before validation
- Test parsing where jersey label and number are separate spans

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895294f422083279dc5a975906872f7