### PR TITLE
Handle split jersey number spans

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -327,9 +327,11 @@ def process_inbound_email(email_body: str, db):
                     ):
                         texts.pop(0)
 
-                    # Remove any leading "Jersey Number" spans
-                    while texts and texts[0].lower().startswith("jersey number"):
+                    # Remove any leading "Jersey Number" span and an immediate numeric value
+                    if texts and texts[0].lower().startswith("jersey number"):
                         texts.pop(0)
+                        if texts and re.fullmatch(r"\d+", texts[0]):
+                            texts.pop(0)
 
                     # Skip rows where the first span looks like a price or lacks letters
                     currency_pattern = r"^\$?[\d,]+(?:\.\d{2})?(?:\s*[:A-Za-z].*)?$"

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -11,7 +11,6 @@ os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
 from app.database import Base
 from app.models import Player, Registration
 from app.email import process_inbound_email, PROMO_CODES
-from datetime import datetime
 
 import pytest
 
@@ -218,6 +217,36 @@ def test_jersey_number_span_removed(db_session):
     assert (
         db_session.query(Player).filter_by(full_name='Jersey Number: 7').first() is None
     )
+
+    regs = db_session.query(Registration).all()
+    assert len(regs) == 1
+    assert regs[0].program == 'Fall Soccer'
+    assert regs[0].division == 'U10'
+
+
+def test_jersey_number_split_span_removed(db_session):
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = 'Order'
+    msg['To'] = 'parent@example.com'
+    html = """
+    <html><body>
+    <table>
+        <tr><td>Order Details</td></tr>
+        <tr>
+            <td><span>Aug 05, 2025 12:29 PM</span><span>Jersey Number:</span><span>7</span><span>John Doe</span></td>
+            <td><span>Fall Soccer - U10</span></td>
+        </tr>
+    </table>
+    </body></html>
+    """
+    msg.attach(MIMEText(html, 'html'))
+
+    process_inbound_email(msg.as_string(), db_session)
+
+    players = db_session.query(Player).all()
+    assert len(players) == 1
+    assert players[0].full_name == 'John Doe'
+    assert db_session.query(Player).filter_by(full_name='7').first() is None
 
     regs = db_session.query(Registration).all()
     assert len(regs) == 1


### PR DESCRIPTION
## Summary
- Strip numeric jersey spans following "Jersey Number" labels before validation
- Test parsing where jersey label and number are separate spans
- Simplify jersey span stripping and tidy test imports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895294f422083279dc5a975906872f7