### PR TITLE
Remove stray debug artifacts in inbound email parsing

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -332,7 +332,6 @@ def process_inbound_email(email_body: str, db):
                     ):
                         texts.pop(0)
 
- 5t4m3o-codex/remove-numeric-span-from-inbound-email
                     # Remove any leading "Jersey Number" span and an immediate numeric value
                     if texts and texts[0].lower().startswith("jersey number"):
                         texts.pop(0)
@@ -346,7 +345,6 @@ def process_inbound_email(email_body: str, db):
                         jersey_label_removed = True
                     if jersey_label_removed and texts and re.match(r"^\d+$", texts[0]):
                         texts.pop(0)
- main
 
                     # Skip rows where the first span looks like a price or lacks letters
                     currency_pattern = r"^\$?[\d,]+(?:\.\d{2})?(?:\s*[:A-Za-z].*)?$"


### PR DESCRIPTION
## Summary
- remove leftover debug line and stray token from jersey-number cleaning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68954783fb3c8327b9a79346d53b72e8