### PR TITLE
Use logging instead of print statements

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -1,6 +1,7 @@
 import os
 import re
 import email
+import logging
 from bs4 import BeautifulSoup
 from datetime import datetime
 from sendgrid import SendGridAPIClient
@@ -8,6 +9,9 @@ from sendgrid.helpers.mail import Mail
 
 from .models import Player, Registration
 from .services.assign import assign_jersey_number
+
+
+logger = logging.getLogger(__name__)
 
 # Promo code mapping based on number of registrations in a single email
 PROMO_CODES = {
@@ -54,11 +58,9 @@ def normalize_division(raw: str) -> str:
     key = re.sub(r"[^A-Za-z0-9]", "", raw or "").upper()
     division = DIVISION_ALIASES.get(key, key)
     if division not in DIVISION_ORDER:
-        print(f"⚠️ Unknown division '{raw}', defaulting to 'Unknown'")
+        logger.warning("Unknown division '%s', defaulting to 'Unknown'", raw)
         return "Unknown"
     return division
-
-print("📬 Loaded email.py")
 
 
 def _plain_text_from_html(html: str) -> str:
@@ -98,15 +100,18 @@ def send_confirmation_email(to_email, players, promo_code=None, registrations=No
     try:
         sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
         response = sg.send(message)
-        print(response.status_code)
-        print(response.body)
-        print(response.headers)
+        logger.debug(
+            "SendGrid response status=%s body=%s headers=%s",
+            response.status_code,
+            response.body,
+            response.headers,
+        )
         if registrations and db and 200 <= response.status_code < 300:
             for reg in registrations:
                 reg.confirmation_sent = True
             db.commit()
     except Exception as e:
-        print(e)
+        logger.error("Error sending confirmation email: %s", e)
 
 
 def send_pines_confirmation_email(to_email, players, registrations=None, db=None):
@@ -138,15 +143,18 @@ def send_pines_confirmation_email(to_email, players, registrations=None, db=None
     try:
         sg = SendGridAPIClient(os.getenv("SENDGRID_API_KEY"))
         response = sg.send(message)
-        print(response.status_code)
-        print(response.body)
-        print(response.headers)
+        logger.debug(
+            "SendGrid response status=%s body=%s headers=%s",
+            response.status_code,
+            response.body,
+            response.headers,
+        )
         if registrations and db and 200 <= response.status_code < 300:
             for reg in registrations:
                 reg.confirmation_sent = True
             db.commit()
     except Exception as e:
-        print(e)
+        logger.error("Error sending pines confirmation email: %s", e)
 
 # Utility for capturing raw inbound emails
 def save_inbound_email(email_body: str, filename: str | None = None) -> None:
@@ -159,12 +167,12 @@ def save_inbound_email(email_body: str, filename: str | None = None) -> None:
     try:
         with open(path, "w") as f:
             f.write(email_body)
-        print(f"📩 Saved inbound email to {path}")
+        logger.info("Saved inbound email to %s", path)
     except Exception as e:
-        print(f"❌ Failed to save inbound email: {e}")
+        logger.error("Failed to save inbound email: %s", e)
 
 def process_inbound_email(email_body: str, db):
-    print("📥 Processing inbound email")
+    logger.info("Processing inbound email")
 
     msg = email.message_from_string(email_body)
     text_content = None
@@ -223,7 +231,7 @@ def process_inbound_email(email_body: str, db):
 
         # Skip adult leagues and camps
         if "Adult League Softball" in full_text or "Camp" in full_text:
-            print("⏭ Skipping non-youth program")
+            logger.info("Skipping non-youth program")
             continue
 
         try:
@@ -241,7 +249,7 @@ def process_inbound_email(email_body: str, db):
             }.items() if not match]
 
             if missing:
-                print(f"❌ Skipping entry, missing: {', '.join(missing)}")
+                logger.warning("Skipping entry, missing: %s", ", ".join(missing))
                 continue
 
             full_name = name_match.group(1).strip()
@@ -284,7 +292,7 @@ def process_inbound_email(email_body: str, db):
             })
 
         except Exception as e:
-            print(f"❌ Error processing registrant block: {e}")
+            logger.error("Error processing registrant block: %s", e)
 
     if not parsed_regs and html_content:
         try:
@@ -411,7 +419,7 @@ def process_inbound_email(email_body: str, db):
                         "season": season,
                     })
         except Exception as e:
-            print(f"❌ Error parsing order details table: {e}")
+            logger.error("Error parsing order details table: %s", e)
 
     promo_code = PROMO_CODES.get(len(parsed_regs))
 
@@ -464,6 +472,10 @@ def process_inbound_email(email_body: str, db):
             existing_reg.order_number = entry["order_number"]
             existing_reg.order_date = entry["order_date"]
             db.commit()
-            print(
-                f"✔ Updated registration for {player.full_name} to {entry['division']} in {entry['sport']} {entry['season']}"
+            logger.info(
+                "Updated registration for %s to %s in %s %s",
+                player.full_name,
+                entry["division"],
+                entry["sport"],
+                entry["season"],
             )

--- a/app/scripts/add_email_column.py
+++ b/app/scripts/add_email_column.py
@@ -1,3 +1,4 @@
+import logging
 from sqlalchemy import create_engine, MetaData, Table
 from sqlalchemy.exc import NoSuchTableError
 
@@ -9,14 +10,16 @@ engine = create_engine(DATABASE_URL)
 metadata = MetaData()
 metadata.reflect(bind=engine)
 
+
+logger = logging.getLogger(__name__)
+
 try:
     players_table = Table("players", metadata, autoload_with=engine)
-
     if "email_sent" not in players_table.columns:
         with engine.connect() as conn:
             conn.execute("ALTER TABLE players ADD COLUMN email_sent BOOLEAN DEFAULT 0")
-        print("✅ 'email_sent' column added.")
+        logger.info("'email_sent' column added.")
     else:
-        print("ℹ️ 'email_sent' column already exists.")
+        logger.info("'email_sent' column already exists.")
 except NoSuchTableError:
-    print("❌ 'players' table not found.")
+    logger.error("'players' table not found.")

--- a/app/seed_data.py
+++ b/app/seed_data.py
@@ -1,8 +1,12 @@
 from datetime import date, datetime
+import logging
 from sqlalchemy.orm import Session
 
 from .database import SessionLocal
 from .models import Player, Registration
+
+
+logger = logging.getLogger(__name__)
 
 def seed_data():
     db: Session = SessionLocal()
@@ -72,7 +76,7 @@ def seed_data():
 
     db.commit()
     db.close()
-    print("✅ Sample data seeded.")
+    logger.info("Sample data seeded.")
 
 if __name__ == "__main__":
     seed_data()

--- a/scripts/add_email_column.py
+++ b/scripts/add_email_column.py
@@ -1,3 +1,4 @@
+import logging
 from sqlalchemy import create_engine, MetaData, Table
 
 # Use the same DATABASE_URL environment variable as app/database.py.
@@ -7,6 +8,9 @@ DATABASE_URL = "sqlite:///./posa.db"
 engine = create_engine(DATABASE_URL)
 metadata = MetaData(bind=engine)
 
+
+logger = logging.getLogger(__name__)
+
 # Reflect the existing table
 players = Table("players", metadata, autoload_with=engine)
 
@@ -14,7 +18,7 @@ players = Table("players", metadata, autoload_with=engine)
 with engine.connect() as conn:
     if "email_sent" not in players.c:
         conn.execute('ALTER TABLE players ADD COLUMN email_sent BOOLEAN DEFAULT 0')
-        print("✅ 'email_sent' column added.")
+        logger.info("'email_sent' column added.")
     else:
-        print("ℹ️ 'email_sent' column already exists.")
+        logger.info("'email_sent' column already exists.")
 

--- a/scripts/add_player.py
+++ b/scripts/add_player.py
@@ -1,8 +1,12 @@
 import argparse
+import logging
 from app.database import SessionLocal
 from app.models import Player, Registration
 from app.services.assign import assign_jersey_number
 from app.email import normalize_division
+
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -30,7 +34,12 @@ def main():
         )
         db.add(reg)
         db.commit()
-        print(f"Added player {player.full_name} (ID {player.id}) with jersey #{jersey}")
+        logger.info(
+            "Added player %s (ID %s) with jersey #%s",
+            player.full_name,
+            player.id,
+            jersey,
+        )
     finally:
         db.close()
 

--- a/scripts/cleanup_empty_divisions.py
+++ b/scripts/cleanup_empty_divisions.py
@@ -1,6 +1,10 @@
 import argparse
+import logging
 from app.database import SessionLocal
 from app.models import Registration
+
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -23,7 +27,7 @@ def main():
             db.rollback()
         else:
             db.commit()
-        print(f"Updated {updated} registrations")
+        logger.info("Updated %d registrations", updated)
     finally:
         db.close()
 

--- a/tests/test_email_parser.py
+++ b/tests/test_email_parser.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import sessionmaker
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from datetime import datetime
+import logging
 
 # Ensure database URL is set before importing application modules
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
@@ -424,7 +425,7 @@ def test_division_normalization(db_session):
     assert reg.division == 'U10'
 
 
-def test_unknown_division_defaults(db_session, capsys):
+def test_unknown_division_defaults(db_session, caplog):
     msg = MIMEMultipart('alternative')
     msg['Subject'] = 'Unknown'
     html = """
@@ -437,9 +438,9 @@ def test_unknown_division_defaults(db_session, capsys):
     """
     msg.attach(MIMEText(html, 'html'))
 
-    process_inbound_email(msg.as_string(), db_session)
-    captured = capsys.readouterr().out
-    assert "Unknown division" in captured
+    with caplog.at_level(logging.WARNING):
+        process_inbound_email(msg.as_string(), db_session)
+    assert "Unknown division" in caplog.text
     reg = db_session.query(Registration).first()
     assert reg.division == 'Unknown'
 

--- a/tests/test_process_email.py
+++ b/tests/test_process_email.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -22,25 +23,25 @@ def db_session():
         session.close()
 
 
-def test_logs_missing_single_field(db_session, capsys):
+def test_logs_missing_single_field(db_session, caplog):
     body = """
 Name: John Doe
 Program: Spring Soccer
 Parent Email: p@example.com
 """
-    process_inbound_email(body, db_session)
-    captured = capsys.readouterr().out
-    assert "Unknown division" in captured
+    with caplog.at_level(logging.WARNING):
+        process_inbound_email(body, db_session)
+    assert "Unknown division" in caplog.text
 
 
-def test_logs_missing_multiple_fields(db_session, capsys):
+def test_logs_missing_multiple_fields(db_session, caplog):
     body = """
 Program: Spring Soccer
 Division: U12
 """
-    process_inbound_email(body, db_session)
-    captured = capsys.readouterr().out
+    with caplog.at_level(logging.WARNING):
+        process_inbound_email(body, db_session)
     # Order of fields may vary
-    assert "missing:" in captured
-    assert "Name" in captured
-    assert "Parent Email" in captured
+    assert "missing:" in caplog.text
+    assert "Name" in caplog.text
+    assert "Parent Email" in caplog.text


### PR DESCRIPTION
## Summary
- Replace all `print` calls in `app/email.py` with `logging` and remove import-time print.
- Extend logging approach to seed data and maintenance scripts for consistent status reporting.
- Update tests to capture log messages instead of stdout.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895482d8e908327a79b307b6ae8af8c