### PR TITLE
refactor: clean up assign service imports

### DIFF
--- a/app/services/assign.py
+++ b/app/services/assign.py
@@ -1,17 +1,20 @@
-from sqlalchemy.orm import Session
-from datetime import datetime
-from ..models import Player
-
-JERSEY_POOL = list(range(1, 100))  # 1–99
-
 def assign_jersey_number(db, division: str) -> int:
-    from app.models import Registration  # local import to avoid circular issues
+    # local import to avoid circular import
+    from app.models import Registration
 
     # Get all registrations for this division
-    regs = db.query(Registration).filter(Registration.division == division).all()
-    
+    regs = (
+        db.query(Registration)
+        .filter(Registration.division == division)
+        .all()
+    )
+
     # Get all jersey numbers already used by players in this division
-    taken = {reg.player.jersey_number for reg in regs if reg.player and reg.player.jersey_number}
+    taken = {
+        reg.player.jersey_number
+        for reg in regs
+        if reg.player and reg.player.jersey_number
+    }
 
     # Find the lowest unused number
     for num in range(1, 100):


### PR DESCRIPTION
## Summary
- remove unused imports and JERSEY_POOL constant in assign service
- format assign service and ensure newline at EOF

## Testing
- `flake8 app/services/assign.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68957ba3513c83278c0caf7b0a4b7df5