### PR TITLE
Handle missing DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This FastAPI application manages player registrations and jersey assignments for
    ```
 
 2. **Configure environment variables**
-   - `DATABASE_URL` – SQLAlchemy connection string to your database
-   - `SECRET_KEY` – secret used for session cookies
+   - `DATABASE_URL` – SQLAlchemy connection string to your database. If unset, defaults to `sqlite:///./app.db`.
+   - `SECRET_KEY` – secret used for session cookies and must be set.
    - `ADMIN_EMAIL` – email for the initial admin account (optional)
    - `ADMIN_PASSWORD` – password for the initial admin account (optional)
 

--- a/app/database.py
+++ b/app/database.py
@@ -7,6 +7,9 @@ from dotenv import load_dotenv
 load_dotenv()  # Load environment variables from .env
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    # Default to a local SQLite database if no URL is provided
+    DATABASE_URL = "sqlite:///./app.db"
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary
- default to local SQLite database when DATABASE_URL is unset
- document required environment variables and default database URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68957ca955d48327aa97d16915f627b5