### PR TITLE
Add migration for player lock state

### DIFF
--- a/alembic/versions/63122e0e89db_add_locked_column_to_players.py
+++ b/alembic/versions/63122e0e89db_add_locked_column_to_players.py
@@ -1,0 +1,31 @@
+"""add locked column to players
+
+Revision ID: 63122e0e89db
+Revises: 067e47789ef7
+Create Date: 2025-08-21 04:15:41.925290
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '63122e0e89db'
+down_revision: Union[str, Sequence[str], None] = '067e47789ef7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "players",
+        sa.Column("locked", sa.Boolean(), nullable=True, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("players", "locked")

--- a/app/main.py
+++ b/app/main.py
@@ -147,6 +147,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
                     "sport": sport_key,
                     "division": division,
                     "confirmation_sent": reg.confirmation_sent,
+                    "locked": player.locked,
                 })
                 continue
             counted_player_ids.add(player.id)
@@ -159,6 +160,7 @@ def admin_dashboard(request: Request, db: Session = Depends(get_db)):
                 "sport": sport_key,
                 "division": division,
                 "confirmation_sent": reg.confirmation_sent,
+                "locked": player.locked,
             })
 
     # Build list of all divisions from defaults and existing data
@@ -248,15 +250,31 @@ class PlayerUpdate(BaseModel):
 async def update_player(player_id: int, player: PlayerUpdate, request: Request, db: Session = Depends(get_db)):
     require_login(request)
     db_player = db.get(Player, player_id)
-    if db_player:
-        db_player.full_name = player.full_name
-        db_player.parent_email = player.parent_email
-        db_player.jersey_number = player.jersey_number
-        db.commit()
-        db.refresh(db_player)
-        return db_player
-    else:
+    if not db_player:
         raise HTTPException(status_code=404, detail="Player not found")
+    if db_player.locked:
+        raise HTTPException(status_code=403, detail="Player is locked")
+    db_player.full_name = player.full_name
+    db_player.parent_email = player.parent_email
+    db_player.jersey_number = player.jersey_number
+    db.commit()
+    db.refresh(db_player)
+    return db_player
+
+
+class LockUpdate(BaseModel):
+    locked: bool
+
+
+@app.put("/players/{player_id}/lock")
+def update_player_lock(player_id: int, lock: LockUpdate, request: Request, db: Session = Depends(get_db)):
+    require_login(request)
+    db_player = db.get(Player, player_id)
+    if not db_player:
+        raise HTTPException(status_code=404, detail="Player not found")
+    db_player.locked = lock.locked
+    db.commit()
+    return {"locked": db_player.locked}
 
 class PlayerCreate(BaseModel):
     full_name: str
@@ -332,6 +350,8 @@ def move_player_division(
     reg = db.get(Registration, registration_id)
     if not reg:
         raise HTTPException(status_code=404, detail="Registration not found")
+    if reg.player.locked:
+        raise HTTPException(status_code=403, detail="Player is locked")
 
     new_division = normalize_division(payload.division)
     reg.division = new_division
@@ -366,12 +386,13 @@ def export_players_csv(request: Request, db: Session = Depends(get_db)):
 def delete_player(player_id: int, request: Request, db: Session = Depends(get_db)):
     require_login(request)
     player = db.get(Player, player_id)
-    if player:
-        db.delete(player)
-        db.commit()
-        return {"message": "Player deleted"}
-    else:
+    if not player:
         raise HTTPException(status_code=404, detail="Player not found")
+    if player.locked:
+        raise HTTPException(status_code=403, detail="Player is locked")
+    db.delete(player)
+    db.commit()
+    return {"message": "Player deleted"}
 
 @app.post("/email/receive")
 async def receive_email(request: Request, db: Session = Depends(get_db)):
@@ -392,6 +413,8 @@ def send_registration_email(registration_id: int, request: Request, db: Session 
     reg = db.get(Registration, registration_id)
     if not reg:
         raise HTTPException(status_code=404, detail="Registration not found")
+    if reg.player.locked:
+        raise HTTPException(status_code=403, detail="Player is locked")
     parent_email = reg.player.parent_email
     regs = (
         db.query(Registration)

--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,7 @@ class Player(Base):
     full_name = Column(String, nullable=False)
     jersey_number = Column(Integer, nullable=True)
     parent_email = Column(String, nullable=False)
+    locked = Column(Boolean, default=False)
 
     registrations = relationship("Registration", back_populates="player", cascade="all, delete-orphan")
 

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% block title %}POSA Admin{% endblock %}
 {% block content %}
+<style>
+    tr.locked td { color: #6c757d; }
+    tr.locked .btn { pointer-events: none; opacity: 0.5; }
+</style>
 <div class="row g-3 mb-4">
     <div class="col-12 col-md-4">
         <div class="bg-white border rounded shadow-sm p-3 text-center">
@@ -59,6 +63,7 @@
                         <table class="table table-bordered align-middle">
                             <thead class="table-light">
                                 <tr>
+                                    <th>Lock</th>
                                     <th>Name</th>
                                     <th>Jersey #</th>
                                     <th>Parent Email</th>
@@ -68,7 +73,12 @@
                             </thead>
                             <tbody data-sport="{{ sport|lower }}" data-division="{{ division }}">
                                 {% for player in players %}
-                                    <tr data-player-id="{{ player.id }}" data-reg-id="{{ player.registration_id }}">
+                                    <tr data-player-id="{{ player.id }}" data-reg-id="{{ player.registration_id }}" class="{% if player.locked %}locked{% endif %}">
+                                        <td>
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input lock-toggle" type="checkbox" {% if player.locked %}checked{% endif %}>
+                                            </div>
+                                        </td>
                                         <td><span class="full-name">{{ player.full_name }}</span><input class="form-control d-none edit-full-name" value="{{ player.full_name }}"></td>
                                         <td><span class="jersey-number">{{ player.jersey_number }}</span><input class="form-control d-none edit-jersey-number" type="number" value="{{ player.jersey_number }}"></td>
                                         <td><span class="parent-email">{{ player.parent_email }}</span><input class="form-control d-none edit-parent-email" value="{{ player.parent_email }}"></td>
@@ -90,11 +100,12 @@
                                     </tr>
                                 {% endfor %}
                                 <tr class="add-row">
-                                    <td colspan="5">
+                                    <td colspan="6">
                                         <button class="btn btn-sm btn-primary btn-show-add-form">Add Player</button>
                                     </td>
                                 </tr>
                                 <tr class="add-form-row d-none">
+                                    <td></td>
                                     <td><input class="form-control new-full-name" placeholder="Full Name"></td>
                                     <td>-</td>
                                     <td><input class="form-control new-parent-email" placeholder="Parent Email"></td>
@@ -114,6 +125,7 @@
                         <table class="table table-bordered align-middle">
                             <thead class="table-light">
                                 <tr>
+                                    <th>Lock</th>
                                     <th>Name</th>
                                     <th>Jersey #</th>
                                     <th>Parent Email</th>
@@ -123,7 +135,12 @@
                             </thead>
                             <tbody data-sport="{{ sport|lower }}" data-division="">
                                 {% for player in players %}
-                                    <tr data-player-id="{{ player.id }}" data-reg-id="{{ player.registration_id }}">
+                                    <tr data-player-id="{{ player.id }}" data-reg-id="{{ player.registration_id }}" class="{% if player.locked %}locked{% endif %}">
+                                        <td>
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input lock-toggle" type="checkbox" {% if player.locked %}checked{% endif %}>
+                                            </div>
+                                        </td>
                                         <td><span class="full-name">{{ player.full_name }}</span><input class="form-control d-none edit-full-name" value="{{ player.full_name }}"></td>
                                         <td><span class="jersey-number">{{ player.jersey_number }}</span><input class="form-control d-none edit-jersey-number" type="number" value="{{ player.jersey_number }}"></td>
                                         <td><span class="parent-email">{{ player.parent_email }}</span><input class="form-control d-none edit-parent-email" value="{{ player.parent_email }}"></td>
@@ -145,11 +162,12 @@
                                     </tr>
                                 {% endfor %}
                                 <tr class="add-row">
-                                    <td colspan="5">
+                                    <td colspan="6">
                                         <button class="btn btn-sm btn-primary btn-show-add-form">Add Player</button>
                                     </td>
                                 </tr>
                                 <tr class="add-form-row d-none">
+                                    <td></td>
                                     <td><input class="form-control new-full-name" placeholder="Full Name"></td>
                                     <td>-</td>
                                     <td><input class="form-control new-parent-email" placeholder="Parent Email"></td>
@@ -280,6 +298,33 @@
         }
     }
 
+    function updateLockState(row, locked) {
+        if (locked) {
+            row.classList.add("locked");
+            row.querySelectorAll("button").forEach(btn => btn.disabled = true);
+        } else {
+            row.classList.remove("locked");
+            row.querySelectorAll("button").forEach(btn => btn.disabled = false);
+        }
+    }
+
+    async function lockHandler(event) {
+        const row = event.currentTarget.closest("tr");
+        const id = row.dataset.playerId;
+        const locked = event.currentTarget.checked;
+        const response = await fetch(`/players/${id}/lock`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ locked })
+        });
+        if (response.ok) {
+            updateLockState(row, locked);
+        } else {
+            alert("Failed to update lock state.");
+            event.currentTarget.checked = !locked;
+        }
+    }
+
     function attachRowHandlers(row) {
         row.querySelector(".btn-edit")?.addEventListener("click", editHandler);
         row.querySelector(".btn-cancel")?.addEventListener("click", cancelHandler);
@@ -287,6 +332,11 @@
         row.querySelector(".btn-delete")?.addEventListener("click", deleteHandler);
         row.querySelector(".btn-send-email")?.addEventListener("click", emailHandler);
         row.querySelector(".btn-move")?.addEventListener("click", moveHandler);
+        const toggle = row.querySelector(".lock-toggle");
+        if (toggle) {
+            toggle.addEventListener("change", lockHandler);
+            updateLockState(row, toggle.checked);
+        }
     }
 
     document.querySelectorAll("tbody tr[data-player-id]").forEach(attachRowHandlers);
@@ -330,6 +380,11 @@
                 row.dataset.playerId = data.id;
                 row.dataset.regId = data.registration_id;
                 row.innerHTML = `
+                    <td>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input lock-toggle" type="checkbox">
+                        </div>
+                    </td>
                     <td><span class="full-name">${data.full_name}</span><input class="form-control d-none edit-full-name" value="${data.full_name}"></td>
                     <td><span class="jersey-number">${data.jersey_number}</span><input class="form-control d-none edit-jersey-number" type="number" value="${data.jersey_number}"></td>
                     <td><span class="parent-email">${data.parent_email}</span><input class="form-control d-none edit-parent-email" value="${data.parent_email}"></td>
@@ -339,6 +394,7 @@
                         <button class="btn btn-sm btn-success btn-save d-none">Save</button>
                         <button class="btn btn-sm btn-secondary btn-cancel d-none">Cancel</button>
                         <button class="btn btn-sm btn-info btn-send-email">Email</button>
+                        <button class="btn btn-sm btn-warning btn-move">Move</button>
                         <button class="btn btn-sm btn-danger btn-delete">Delete</button>
                     </td>
                 `;

--- a/tests/test_player_lock.py
+++ b/tests/test_player_lock.py
@@ -1,0 +1,60 @@
+import os
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['CURRENT_SEASON'] = '2024'
+
+from fastapi.testclient import TestClient
+import app.main as app_main
+from app.main import app, Base, get_db
+from app.models import Player
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app_main.require_login = lambda request: None
+    app.router.on_startup.clear()
+
+    with TestClient(app) as c:
+        c.SessionLocal = TestingSessionLocal
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def test_lock_unlock_player(client):
+    db = client.SessionLocal()
+    player = Player(full_name='Test', parent_email='t@example.com', jersey_number=10)
+    db.add(player)
+    db.commit()
+    db.refresh(player)
+    db.close()
+
+    response = client.put(f"/players/{player.id}/lock", json={"locked": True})
+    assert response.status_code == 200
+    assert response.json()["locked"] is True
+
+    db = client.SessionLocal()
+    assert db.get(Player, player.id).locked is True
+    db.close()
+
+    response = client.put(f"/players/{player.id}/lock", json={"locked": False})
+    assert response.status_code == 200
+    db = client.SessionLocal()
+    assert db.get(Player, player.id).locked is False
+    db.close()


### PR DESCRIPTION
## Summary
- add Alembic migration adding a `locked` column to the `players` table

## Testing
- `pytest -q`
- `alembic upgrade head` *(fails: no such table: registrations)*

------
https://chatgpt.com/codex/tasks/task_e_68a6936cda208327b3f90320c7c3756c