### PR TITLE
Add migration for player lock column

### DIFF
--- a/alembic/versions/3bfc7bb3b155_create_base_tables.py
+++ b/alembic/versions/3bfc7bb3b155_create_base_tables.py
@@ -26,7 +26,6 @@ def upgrade() -> None:
     sa.Column('full_name', sa.String(), nullable=False),
     sa.Column('jersey_number', sa.Integer(), nullable=True),
     sa.Column('parent_email', sa.String(), nullable=False),
-    sa.Column('locked', sa.Boolean(), nullable=True),
     sa.PrimaryKeyConstraint('id'),
     sa.UniqueConstraint('full_name', name='uq_fullname')
     )

--- a/alembic/versions/63122e0e89db_add_locked_column_to_players.py
+++ b/alembic/versions/63122e0e89db_add_locked_column_to_players.py
@@ -1,0 +1,25 @@
+"""Add locked column to players
+
+Revision ID: 63122e0e89db
+Revises: 3bfc7bb3b155
+Create Date: 2024-08-21 04:31:12.382556
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '63122e0e89db'
+down_revision: Union[str, Sequence[str], None] = '3bfc7bb3b155'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('players', sa.Column('locked', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('players', 'locked')


### PR DESCRIPTION
## Summary
- add alembic revision to add `locked` column to `players`
- remove `locked` column from base table migration

## Testing
- `alembic -c $tmpfile upgrade head`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a31849dc8327b65ca95d85e4f68f