### PR TITLE
Add endpoint to register existing players for new seasons

### DIFF
--- a/app/api_routes.py
+++ b/app/api_routes.py
@@ -2,7 +2,7 @@
 New Admin API Routes for Drill-Down Interface
 """
 import re
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func, extract, cast, Integer
@@ -337,6 +337,54 @@ def create_player(player_data: Dict[str, Any], db: Session = Depends(get_db)):
 
     db.commit()
     return {"id": player.id, "name": player.full_name}
+
+
+@router.post("/players/{player_id}/registrations")
+def add_registration_to_player(
+    player_id: int,
+    reg_data: dict = Body(...),
+    db: Session = Depends(get_db),
+):
+    """Add a registration to an existing player."""
+    player = db.query(Player).filter(Player.id == player_id).first()
+    if not player:
+        raise HTTPException(status_code=404, detail="Player not found")
+
+    sport = (reg_data.get("sport") or "").strip()
+    season = (reg_data.get("season") or "").strip()
+    division = (reg_data.get("division") or "").strip()
+    if not sport or not season:
+        raise HTTPException(status_code=400, detail="sport and season are required")
+
+    # Check for duplicate registration
+    existing = db.query(Registration).filter(
+        Registration.player_id == player_id,
+        func.lower(Registration.sport) == sport.lower(),
+        Registration.season == season,
+    ).first()
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail=f"{player.full_name} already has a {sport}/{season} registration",
+        )
+
+    reg = Registration(
+        player_id=player.id,
+        program=reg_data.get("program", sport),
+        sport=sport,
+        division=division,
+        season=season,
+        confirmation_sent=reg_data.get("confirmation_sent", False),
+    )
+    db.add(reg)
+    db.commit()
+    return {
+        "id": reg.id,
+        "player": player.full_name,
+        "sport": sport,
+        "season": season,
+        "division": division,
+    }
 
 
 @router.get("/waiting-room")


### PR DESCRIPTION
## Summary
- Adds `POST /api/admin/players/{id}/registrations` endpoint
- Allows adding a registration (sport/season/division) to an existing player
- Needed when SportsEngine API doesn't return a kid's profile for a registration form (family registration issue) but the player already exists in the DB from a previous season

## Context
Carsen George and David Lambert are registered for Spring 2026 Soccer in SportsEngine's CSV export (108 total), but the SE API's `REGISTRATION_SUBMITTED` profile filter doesn't return their profiles for that form. They already exist in the DB from Fall 2025 but lack Spring 2026 registrations. This endpoint provides a clean way to add the missing registrations.

## Test plan
- [ ] `POST /api/admin/players/276/registrations` with `{"sport": "Soccer", "season": "Spring 2026", "division": "U8 = 2018 & 2019 birth year"}` → creates registration for Carsen George
- [ ] `POST /api/admin/players/257/registrations` with same (with U14 division) → creates registration for David Lambert
- [ ] Duplicate POST returns 409
- [ ] Invalid player_id returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)