### PR TITLE
Add force-refresh mode to members sync

### DIFF
--- a/app/members_routes.py
+++ b/app/members_routes.py
@@ -23,13 +23,13 @@ _sync_status = {
 }
 
 
-def _run_sync_background():
+def _run_sync_background(force: bool = False):
     """Run members sync in a background thread with its own DB session."""
     global _sync_status
     db = SessionLocal()
     try:
         from app.services.members_sync import sync_members
-        results = sync_members(db)
+        results = sync_members(db, force=force)
         _sync_status["results"] = results
         _sync_status["error"] = None
     except Exception as e:
@@ -42,8 +42,10 @@ def _run_sync_background():
 
 
 @router.post("/api/members/sync")
-def members_sync():
-    """Kick off members sync in background thread. Returns immediately."""
+def members_sync(force: bool = False):
+    """Kick off members sync in background thread. Returns immediately.
+    Pass ?force=true to re-fetch all profiles (picks up name changes, etc.).
+    """
     from app.services.sportsengine import is_configured
 
     if not is_configured():
@@ -59,10 +61,10 @@ def members_sync():
     _sync_status["results"] = None
     _sync_status["error"] = None
 
-    thread = threading.Thread(target=_run_sync_background, daemon=True)
+    thread = threading.Thread(target=_run_sync_background, kwargs={"force": force}, daemon=True)
     thread.start()
 
-    return {"status": "started"}
+    return {"status": "started", "mode": "full" if force else "incremental"}
 
 
 @router.get("/api/members/sync-status")

--- a/app/services/members_sync.py
+++ b/app/services/members_sync.py
@@ -86,11 +86,14 @@ query GetProfile($profileId: Int!, $orgId: Int!) {
 """
 
 
-def sync_members(db: Session) -> dict:
+def sync_members(db: Session, force: bool = False) -> dict:
     """
     Sync all member profiles from SportsEngine into the members table.
     Step 1: List all profile IDs page by page (SimpleProfile).
     Step 2: Fetch each profile individually for full data (Profile).
+
+    If force=True, re-fetch ALL profiles (not just new ones) so name
+    changes, membership updates, etc. are picked up.
     """
     import os
     from app.models_members import Member, MemberGuardian
@@ -111,11 +114,16 @@ def sync_members(db: Session) -> dict:
     }
 
     # Collect all known SE profile IDs for incremental sync
-    known_ids = set(
-        row[0] for row in db.query(Member.se_profile_id).all()
-    )
-    if known_ids:
-        print(f"MEMBERS SYNC: {len(known_ids)} profiles already in DB", flush=True)
+    # When force=True, skip nothing — re-fetch every profile
+    if force:
+        known_ids = set()
+        print("MEMBERS SYNC: FULL refresh — re-fetching all profiles", flush=True)
+    else:
+        known_ids = set(
+            row[0] for row in db.query(Member.se_profile_id).all()
+        )
+        if known_ids:
+            print(f"MEMBERS SYNC: {len(known_ids)} profiles already in DB", flush=True)
 
     page = 1
     total_pages = None


### PR DESCRIPTION
## Summary
- Adds `?force=true` parameter to `POST /api/members/sync`
- When force=true, re-fetches ALL profiles from SportsEngine instead of skipping known ones
- Updates existing member records with current names, contact info, and memberships

## Context
The Wright kids were renamed in SportsEngine (from "clarissa sumpter" to their real names), but the incremental members sync skipped them because their SE profile IDs were already in the DB. Locke Lambert is also in the members table but has no membership data. A force sync will refresh all records.

## Test plan
- [ ] `POST /api/members/sync` (no param) → incremental sync, skips existing
- [ ] `POST /api/members/sync?force=true` → full refresh, updates all profiles
- [ ] After force sync, Wright kids appear with correct names
- [ ] After force sync, Locke Lambert has updated membership info

🤖 Generated with [Claude Code](https://claude.com/claude-code)