### PR TITLE
Fix evaluation save feedback and reload saved values

### DIFF
--- a/app/templates/evaluations_page.html
+++ b/app/templates/evaluations_page.html
@@ -96,8 +96,8 @@
           <h4 class="font-semibold text-sm text-gray-900 mb-3">Players</h4>
           <div x-show="players.length === 0" class="text-sm text-gray-500">No players found for this selected registration yet.</div>
           <div class="space-y-1 max-h-[32rem] overflow-y-auto">
-            <template x-for="player in players" :key="player.playerId">
-              <button @click="selectPlayer(player)" class="w-full text-left px-3 py-2 rounded-lg text-sm hover:bg-gray-50" :class="selectedPlayer && selectedPlayer.playerId === player.playerId ? 'bg-pines-50 text-pines-800 font-semibold' : 'text-gray-800'">
+            <template x-for="player in players" :key="player.sessionPlayerId || player.playerId || player.playerName">
+              <button @click="selectPlayer(player)" class="w-full text-left px-3 py-2 rounded-lg text-sm hover:bg-gray-50" :class="selectedPlayer && selectedPlayer.playerName === player.playerName ? 'bg-pines-50 text-pines-800 font-semibold' : 'text-gray-800'">
                 <span x-text="player.playerName"></span>
                 <span class="text-xs text-gray-500" x-text="player.division ? ' • ' + player.division : ''"></span>
               </button>
@@ -110,6 +110,7 @@
             <div>
               <h4 class="font-semibold text-gray-900" x-text="selectedPlayer ? selectedPlayer.playerName : ''"></h4>
               <p class="text-xs text-gray-500" x-text="selectedPlayer ? [selectedPlayer.ageGroup, selectedPlayer.division].filter(Boolean).join(' • ') : ''"></p>
+              <p class="text-xs text-pines-700 mt-1" x-show="savedStatus" x-text="savedStatus"></p>
             </div>
             <a x-show="selectedPlayer" :href="'/api/evaluations/sessions/' + selectedSession.id + '/players/' + encodeURIComponent(selectedPlayer.playerName) + '/pdf'" class="px-3 py-1.5 text-xs rounded-lg border border-gray-200 hover:bg-gray-50"><i class="fa-regular fa-file-pdf mr-1"></i>Player PDF</a>
           </div>
@@ -117,7 +118,7 @@
           <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-4">
             <div>
               <label class="block text-xs font-semibold text-gray-700 mb-1">Evaluator Name</label>
-              <input x-model="evaluation.evaluatorName" class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm">
+              <input x-model="evaluation.evaluatorName" placeholder="Evaluator" class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm">
             </div>
             <div>
               <label class="block text-xs font-semibold text-gray-700 mb-1">Primary Position</label>
@@ -186,10 +187,11 @@
   <script>
   function evaluationsApp() {
     return {
-      loading:false, creating:false, error:'', message:'', registrations:[], sessions:[], players:[], categories:{}, selectedSession:null, selectedPlayer:null, prompt:'',
+      loading:false, creating:false, error:'', message:'', registrations:[], sessions:[], players:[], categories:{}, selectedSession:null, selectedPlayer:null, prompt:'', savedStatus:'',
       newSession:{name:'', registrationId:''},
       evaluation:{evaluatorName:'', primaryPosition:'', futurePotential:'', biggestStrength:'', biggestGrowthArea:'', notes:'', scores:{}},
       async init(){ await this.loadAll(); },
+      blankEvaluation(){ return {evaluatorName:'', primaryPosition:'', futurePotential:'', biggestStrength:'', biggestGrowthArea:'', notes:'', scores:{}}; },
       async api(url, options){
         const res = await fetch(url, options || {});
         let data = {};
@@ -206,23 +208,52 @@
         this.error=''; this.message=''; this.creating=true;
         try {
           const data = await this.api('/api/evaluations/sessions', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ name:this.newSession.name, sportsengine_registration_id:this.newSession.registrationId }) });
-          this.message = 'Session created. Synced ' + ((data.syncResults && (data.syncResults.new_players + data.syncResults.existing_players)) || 0) + ' players.';
+          this.message = 'Session created. Synced ' + ((data.syncResults && (data.syncResults.session_players || data.syncResults.new_players + data.syncResults.existing_players)) || 0) + ' players.';
           this.newSession = {name:'', registrationId:''};
           await this.loadSessions();
           if (data.session) await this.selectSession(data.session);
         } catch(e){ this.error=e.message; }
         finally { this.creating=false; }
       },
-      async selectSession(session){ this.selectedSession=session; this.selectedPlayer=null; this.players=[]; this.error=''; try { const data=await this.api('/api/evaluations/sessions/'+session.id+'/players'); this.players=data.players || []; } catch(e){ this.error=e.message; } },
-      selectPlayer(player){ this.selectedPlayer=player; this.evaluation={evaluatorName:'', primaryPosition:'', futurePotential:'', biggestStrength:'', biggestGrowthArea:'', notes:'', scores:{}}; },
+      async selectSession(session){ this.selectedSession=session; this.selectedPlayer=null; this.players=[]; this.savedStatus=''; this.error=''; try { const data=await this.api('/api/evaluations/sessions/'+session.id+'/players'); this.players=data.players || []; } catch(e){ this.error=e.message; } },
+      async selectPlayer(player){
+        this.selectedPlayer=player;
+        this.evaluation=this.blankEvaluation();
+        this.savedStatus='Checking saved evaluation...';
+        await this.loadSavedEvaluation();
+      },
+      async loadSavedEvaluation(){
+        if (!this.selectedSession || !this.selectedPlayer) return;
+        try {
+          const data = await this.api('/api/evaluations/sessions/'+this.selectedSession.id+'/players/'+encodeURIComponent(this.selectedPlayer.playerName)+'/prompt');
+          const summary = data.summary || {};
+          const scores = summary.categoryScores || {};
+          const formScores = {};
+          Object.keys(scores).forEach((key) => { if (key !== 'Future Potential') formScores[key] = scores[key] ? String(Math.round(Number(scores[key]))) : ''; });
+          this.evaluation = {
+            evaluatorName: '',
+            primaryPosition: summary.position || '',
+            futurePotential: scores['Future Potential'] ? String(Math.round(Number(scores['Future Potential']))) : '',
+            biggestStrength: (summary.evaluatorStrengths && summary.evaluatorStrengths[0]) || '',
+            biggestGrowthArea: (summary.evaluatorGrowthAreas && summary.evaluatorGrowthAreas[0]) || '',
+            notes: (summary.notes || []).join('\n'),
+            scores: formScores
+          };
+          this.savedStatus = 'Saved evaluation loaded.';
+        } catch(e) {
+          this.savedStatus = 'No saved evaluation yet.';
+        }
+      },
       async saveEvaluation(){
         if (!this.selectedSession || !this.selectedPlayer) return;
-        this.error=''; this.message='';
+        this.error=''; this.message=''; this.savedStatus='Saving...';
         try {
-          await this.api('/api/evaluations/sessions/'+this.selectedSession.id+'/evaluations', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ player_id:this.selectedPlayer.playerId, player_name:this.selectedPlayer.playerName, evaluator_name:this.evaluation.evaluatorName, primary_position:this.evaluation.primaryPosition, future_potential:this.evaluation.futurePotential, biggest_strength:this.evaluation.biggestStrength, biggest_growth_area:this.evaluation.biggestGrowthArea, notes:this.evaluation.notes, scores:this.evaluation.scores }) });
-          this.message='Evaluation saved.';
+          const data = await this.api('/api/evaluations/sessions/'+this.selectedSession.id+'/evaluations', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ player_id:this.selectedPlayer.playerId, player_name:this.selectedPlayer.playerName, evaluator_name:this.evaluation.evaluatorName || 'Evaluator', primary_position:this.evaluation.primaryPosition, future_potential:this.evaluation.futurePotential, biggest_strength:this.evaluation.biggestStrength, biggest_growth_area:this.evaluation.biggestGrowthArea, notes:this.evaluation.notes, scores:this.evaluation.scores }) });
+          this.message='Evaluation saved (' + (data.scoresSaved || 0) + ' scores).';
+          this.savedStatus='Saved. Total evaluations for player: ' + (data.totalEvaluationsForPlayer || 1) + '.';
           await this.loadSessions();
-        } catch(e){ this.error=e.message; }
+          await this.loadSavedEvaluation();
+        } catch(e){ this.error=e.message; this.savedStatus='Save failed.'; }
       },
       async loadPrompt(){
         if (!this.selectedSession || !this.selectedPlayer) return;


### PR DESCRIPTION
## Summary

Fixes the evaluation scoring UX so saves are easier to verify and saved values reload when switching between players.

## Problem

After clicking **Save Evaluation**, the page could appear to blink/reset. Switching to another player and back showed a blank form because the UI was not loading saved evaluation data back into the form. Also, a blank evaluator name caused the API to reject the save, but the error was easy to miss.

## Changes

- Defaults blank evaluator names to `Evaluator` instead of rejecting the save.
- Returns `scoresSaved`, `totalEvaluationsForPlayer`, and updated session counts from the save endpoint.
- Adds saved-status messages in the evaluation UI.
- When selecting a player, attempts to load saved evaluation data and prefill the score fields from the saved summary.
- After saving, reloads the saved values and shows confirmation.

## Notes

This preserves the multiple-evaluator workflow: saving again creates another evaluation entry, and the loaded values represent the averaged saved summary for that player.