### PR TITLE
Keep edited evaluation scores visible after save

### DIFF
--- a/app/templates/evaluations_page.html
+++ b/app/templates/evaluations_page.html
@@ -252,7 +252,6 @@
           this.message='Evaluation saved (' + (data.scoresSaved || 0) + ' scores).';
           this.savedStatus='Saved. Total evaluations for player: ' + (data.totalEvaluationsForPlayer || 1) + '.';
           await this.loadSessions();
-          await this.loadSavedEvaluation();
         } catch(e){ this.error=e.message; this.savedStatus='Save failed.'; }
       },
       async loadPrompt(){


### PR DESCRIPTION
## Summary
- stop reloading the aggregate player summary immediately after saving an evaluation
- keep the score values the evaluator just selected visible in the interface after save
- still refresh session counts after saving

## Why
The save endpoint is updating the stored scores, but the UI immediately reloads the player prompt/summary endpoint after saving. That endpoint returns aggregate summary values instead of the single saved evaluation, which can make recently changed scores appear unchanged or reverted in the form.