### PR TITLE
Load dashboard high school toggle without cached sidebar script

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -48,13 +48,24 @@ def _read_template(name: str) -> str:
         return f.read()
 
 
+def _admin_dashboard_template() -> str:
+    html = _read_template("players_page.html")
+    script = '    <script src="/static/dashboard-high-school-toggle.js?v=1"></script>'
+    if "dashboard-high-school-toggle.js" not in html:
+        html = html.replace(
+            '    <script src="/static/sidebar.js"></script>',
+            f"{script}\n    <script src=\"/static/sidebar.js\"></script>",
+        )
+    return html
+
+
 @app.get("/")
 async def home():
     return {"status": "ok"}
 
 @app.get("/admin", response_class=HTMLResponse)
 async def admin_dashboard(request: Request):
-    return HTMLResponse(_read_template("players_page.html"))
+    return HTMLResponse(_admin_dashboard_template())
 
 @app.get("/admin/add", response_class=HTMLResponse)
 async def admin_add_player():

--- a/app/static/dashboard-high-school-toggle.js
+++ b/app/static/dashboard-high-school-toggle.js
@@ -1,0 +1,102 @@
+(function() {
+  'use strict';
+
+  if (typeof window.tableApp !== 'function' || window.tableApp.__highSchoolDashboardPatched) return;
+
+  function playerPayload(player) {
+    var payload = {
+      full_name: player.name,
+      parent_email: player.email,
+      jersey_number: player.jersey,
+      is_high_school: !!player.isHighSchool
+    };
+    if (player.dateOfBirth) {
+      payload.date_of_birth = player.dateOfBirth;
+    } else {
+      payload.birth_year = player.birthYear || null;
+    }
+    return payload;
+  }
+
+  function insertToggle() {
+    document.querySelectorAll('template').forEach(function(template) {
+      if (template.content.querySelector('[x-model="selectedPlayer.isHighSchool"]')) return;
+
+      var emailInput = template.content.querySelector('[x-model="selectedPlayer.email"]');
+      if (!emailInput) return;
+
+      var emailBlock = emailInput.closest('div');
+      if (!emailBlock || !emailBlock.parentNode) return;
+
+      var wrapper = document.createElement('div');
+      wrapper.innerHTML = '' +
+        '<label class="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3">' +
+          '<input type="checkbox" x-model="selectedPlayer.isHighSchool" class="mt-0.5 rounded border-gray-300 text-pines-500 focus:ring-pines-500">' +
+          '<span>' +
+            '<span class="block text-sm font-medium text-gray-900">High School Player</span>' +
+            '<span class="block text-xs text-gray-500">Uses the high school email template.</span>' +
+          '</span>' +
+        '</label>';
+      emailBlock.parentNode.insertBefore(wrapper.firstElementChild, emailBlock.nextSibling);
+    });
+  }
+
+  var originalTableApp = window.tableApp;
+  window.tableApp = function() {
+    var app = originalTableApp.apply(this, arguments);
+
+    app.buildPlayerPayload = playerPayload;
+
+    app.savePanel = async function() {
+      try {
+        var response = await fetch('/api/players/' + this.selectedPlayer.id, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(this.buildPlayerPayload(this.selectedPlayer))
+        });
+        var data = await response.json();
+        if (data.success) {
+          await this.loadPlayers();
+          this.closePanel();
+        }
+      } catch (error) {
+        console.error('Failed to update player:', error);
+        alert('Failed to update player');
+      }
+    };
+
+    app.sendEmail = async function(player) {
+      try {
+        if (this.selectedPlayer && this.selectedPlayer.id === player.id) {
+          var saveResponse = await fetch('/api/players/' + this.selectedPlayer.id, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(this.buildPlayerPayload(this.selectedPlayer))
+          });
+          var saveData = await saveResponse.json();
+          if (!saveData.success) {
+            alert('Failed: ' + (saveData.error || 'Could not save player before sending email'));
+            return;
+          }
+        }
+
+        var response = await fetch('/api/admin/players/' + player.id + '/send-email', { method: 'POST' });
+        var data = await response.json();
+        if (data.success) {
+          alert('Email sent to ' + player.email);
+          await this.loadPlayers();
+        } else {
+          alert('Failed: ' + (data.message || data.error));
+        }
+      } catch (error) {
+        console.error('Failed to send email:', error);
+        alert('Failed to send email');
+      }
+    };
+
+    return app;
+  };
+
+  window.tableApp.__highSchoolDashboardPatched = true;
+  insertToggle();
+})();


### PR DESCRIPTION
## What changed

Adds a cache-proof dashboard toggle fix:

- `/admin` now includes a versioned `/static/dashboard-high-school-toggle.js?v=1` script before the sidebar script
- the new script inserts the `High School Player` checkbox into the player detail drawer
- saving the drawer and sending jersey email both include `is_high_school`
- sending email first saves the current drawer state so the high school template is selected immediately

## Why

PR #192 patched `sidebar.js`, but that can be missed by browser/static caching and only ran for an exact `/admin` path. This follow-up loads a new versioned script from the dashboard response itself.

## Validation

- Compiled `app/main.py` successfully with `py_compile`
- Verified the branch diff is limited to `app/main.py` and the new dashboard script