### PR TITLE
Fix email template save buttons

### DIFF
--- a/app/static/email-templates.js
+++ b/app/static/email-templates.js
@@ -1,0 +1,76 @@
+(function() {
+  'use strict';
+
+  function showMessage(id) {
+    var message = document.getElementById(id);
+    if (!message) return;
+    message.style.display = 'block';
+    setTimeout(function() {
+      message.style.display = 'none';
+    }, 3000);
+  }
+
+  async function saveTemplate(config) {
+    var subjectInput = document.getElementById(config.subjectId);
+    var bodyInput = document.getElementById(config.bodyId);
+    if (!subjectInput || !bodyInput) return;
+
+    try {
+      var response = await fetch('/email-templates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: config.name,
+          subject: subjectInput.value,
+          body_html: bodyInput.value
+        })
+      });
+
+      var data = await response.json().catch(function() { return {}; });
+      if (!response.ok || data.success === false) {
+        throw new Error(data.error || 'Failed to save template');
+      }
+
+      showMessage(config.successId);
+    } catch (error) {
+      console.error('Failed to save email template:', error);
+      showMessage(config.errorId);
+    }
+  }
+
+  function bindForm(config) {
+    var form = document.getElementById(config.formId);
+    if (!form || form.dataset.emailTemplateBound === 'true') return;
+
+    form.dataset.emailTemplateBound = 'true';
+    form.addEventListener('submit', function(event) {
+      event.preventDefault();
+      saveTemplate(config);
+    });
+  }
+
+  function initEmailTemplateForms() {
+    bindForm({
+      formId: 'standard-form',
+      subjectId: 'standard-subject',
+      bodyId: 'standard-body',
+      successId: 'standard-success',
+      errorId: 'standard-error',
+      name: 'standard_confirmation'
+    });
+    bindForm({
+      formId: 'pines-form',
+      subjectId: 'pines-subject',
+      bodyId: 'pines-body',
+      successId: 'pines-success',
+      errorId: 'pines-error',
+      name: 'pines_confirmation'
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initEmailTemplateForms);
+  } else {
+    initEmailTemplateForms();
+  }
+})();

--- a/app/templates/email_templates.html
+++ b/app/templates/email_templates.html
@@ -215,5 +215,6 @@
         });
     </script>
     <script src="/static/sidebar.js"></script>
+    <script src="/static/email-templates.js?v=1"></script>
 </body>
 </html>


### PR DESCRIPTION
## What changed

Fixes the Email Templates page save buttons by adding a page-specific save script loaded after `sidebar.js`.

The new script:
- binds the Standard and Pines template forms after the sidebar layout rebuilds the DOM
- posts the template name, subject, and HTML body to `/email-templates`
- shows the existing success/error messages based on the save response

## Why

The inline form handlers were attached before `sidebar.js` rebuilt the page layout. That rebuild replaced the form DOM nodes, so the Save buttons no longer had working submit handlers.

## Validation

- Confirmed the new script is loaded after `sidebar.js`
- Checked JavaScript syntax with the bundled Node runtime
- Confirmed the branch diff is limited to `app/templates/email_templates.html` and `app/static/email-templates.js`