### PR TITLE
Wire player merge admin workflow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from app.events_routes import router as events_router
 from app.members_routes import router as members_router
 from app.seasons_routes import router as seasons_router
 from app.evaluations_routes import router as evaluations_router
+from app.player_merge_routes import router as player_merge_router
 
 Base.metadata.create_all(bind=engine)
 ensure_player_date_of_birth_column(engine)
@@ -39,6 +40,7 @@ app.include_router(events_router)
 app.include_router(members_router)
 app.include_router(seasons_router)
 app.include_router(evaluations_router)
+app.include_router(player_merge_router)
 
 _TEMPLATES_DIR = pathlib.Path(__file__).parent / "templates"
 
@@ -70,6 +72,10 @@ async def admin_dashboard(request: Request):
 @app.get("/admin/add", response_class=HTMLResponse)
 async def admin_add_player():
     return HTMLResponse(_read_template("player_add.html"))
+
+@app.get("/admin/merge", response_class=HTMLResponse)
+async def admin_merge_players():
+    return HTMLResponse(_read_template("player_merge.html"))
 
 @app.get("/admin/volunteers", response_class=HTMLResponse)
 async def admin_volunteers(request: Request):

--- a/app/templates/player_merge.html
+++ b/app/templates/player_merge.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Merge Players - POSA</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    pines: { 50: '#f0f7f0', 100: '#d9edd9', 200: '#b3dbb3', 300: '#7fc07f', 400: '#5aa55a', 500: '#3C7939', 600: '#2f6130', 700: '#254d26', 800: '#1c3a1d', 900: '#142914' }
+                }
+            }
+        }
+    }
+    </script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <style>[x-cloak] { display: none !important; }</style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
+</head>
+<body class="bg-gray-50" x-data="playerMergeApp()" x-init="init()" x-cloak>
+    <div class="bg-white border-b border-gray-200 px-6 py-4">
+        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+                <div class="flex items-center text-sm text-gray-500 mb-0.5">
+                    <a href="/admin" class="hover:text-pines-600 transition-colors">Players</a>
+                    <i class="fa-solid fa-chevron-right text-[10px] mx-2 text-gray-400"></i>
+                    <span class="text-gray-900 font-medium">Merge Players</span>
+                </div>
+                <h1 class="text-xl font-semibold text-gray-900">Merge Duplicate Players</h1>
+            </div>
+            <div class="flex items-center gap-2">
+                <button type="button" @click="loadPlayers()" :disabled="loading" class="inline-flex items-center justify-center w-9 h-9 rounded-lg border border-gray-200 text-gray-700 hover:bg-gray-50 disabled:opacity-50" title="Refresh players">
+                    <i class="fa-solid fa-arrows-rotate text-sm" :class="loading ? 'animate-spin' : ''"></i>
+                </button>
+                <a href="/admin" class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                    <i class="fa-solid fa-list text-xs"></i>
+                    All Players
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <main class="px-6 py-5">
+        <div x-show="successMessage" x-transition class="mb-4 bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg text-sm font-medium flex items-center justify-between">
+            <span x-text="successMessage"></span>
+            <button type="button" @click="successMessage = ''" class="text-green-600 hover:text-green-800" title="Dismiss"><i class="fa-solid fa-xmark"></i></button>
+        </div>
+        <div x-show="errorMessage" x-transition class="mb-4 bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg text-sm font-medium flex items-center justify-between">
+            <span x-text="errorMessage"></span>
+            <button type="button" @click="errorMessage = ''" class="text-red-600 hover:text-red-800" title="Dismiss"><i class="fa-solid fa-xmark"></i></button>
+        </div>
+
+        <div class="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_24rem] gap-5 items-start">
+            <section class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                <div class="px-4 py-3 border-b border-gray-200 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-pines-50 text-pines-700"><i class="fa-solid fa-magnifying-glass text-sm"></i></span>
+                        <div>
+                            <h2 class="text-sm font-semibold text-gray-900">Player Records</h2>
+                            <p class="text-xs text-gray-500" x-text="filteredPlayers.length + ' shown of ' + players.length"></p>
+                        </div>
+                    </div>
+                    <div class="relative w-full lg:w-80">
+                        <i class="fa-solid fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-400"></i>
+                        <input type="search" x-model="search" placeholder="Search name, email, DOB, jersey" class="w-full pl-9 pr-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-pines-500 focus:border-transparent">
+                    </div>
+                </div>
+
+                <div x-show="loading" class="py-16 text-center">
+                    <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-pines-500"></div>
+                    <p class="mt-3 text-sm text-gray-600">Loading players...</p>
+                </div>
+                <div x-show="!loading && filteredPlayers.length === 0" class="py-16 text-center text-sm text-gray-500">No matching players</div>
+
+                <div x-show="!loading && filteredPlayers.length > 0" class="divide-y divide-gray-100 max-h-[calc(100vh-15rem)] overflow-y-auto">
+                    <template x-for="player in filteredPlayers.slice(0, 250)" :key="player.id">
+                        <button type="button" @click="togglePlayer(player)" class="w-full text-left px-4 py-3 hover:bg-gray-50 transition-colors" :class="isSelected(player.id) ? 'bg-pines-50 hover:bg-pines-50' : 'bg-white'">
+                            <div class="flex items-start gap-3">
+                                <span class="mt-1 inline-flex items-center justify-center w-5 h-5 rounded border" :class="isSelected(player.id) ? 'bg-pines-500 border-pines-500 text-white' : 'border-gray-300 text-transparent'"><i class="fa-solid fa-check text-[10px]"></i></span>
+                                <div class="min-w-0 flex-1">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <span class="text-sm font-semibold text-gray-900" x-text="player.name"></span>
+                                        <span class="text-[11px] text-gray-400" x-text="'#' + player.id"></span>
+                                        <span x-show="candidateReason(player)" class="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-amber-50 text-amber-700 border border-amber-200" x-text="candidateReason(player)"></span>
+                                        <span x-show="player.isHighSchool" class="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-indigo-50 text-indigo-700 border border-indigo-200">High School</span>
+                                        <span x-show="player.locked" class="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-gray-100 text-gray-700 border border-gray-200">Volunteer</span>
+                                    </div>
+                                    <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+                                        <span><i class="fa-regular fa-envelope mr-1 text-gray-400"></i><span x-text="player.email || 'No email'"></span></span>
+                                        <span><i class="fa-regular fa-calendar mr-1 text-gray-400"></i><span x-text="dateLabel(player)"></span></span>
+                                        <span><i class="fa-solid fa-shirt mr-1 text-gray-400"></i><span x-text="jerseyLabel(player)"></span></span>
+                                    </div>
+                                    <div class="mt-2 flex flex-wrap gap-1">
+                                        <template x-for="reg in player.registrations.slice(0, 4)" :key="reg.id">
+                                            <span class="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-[11px] text-gray-700" x-text="registrationLabel(reg)"></span>
+                                        </template>
+                                        <span x-show="player.registrations.length > 4" class="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-[11px] text-gray-500" x-text="'+' + (player.registrations.length - 4)"></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </button>
+                    </template>
+                </div>
+            </section>
+
+            <aside class="space-y-4">
+                <section class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                    <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+                        <div>
+                            <h2 class="text-sm font-semibold text-gray-900">Selected</h2>
+                            <p class="text-xs text-gray-500" x-text="selectedPlayers.length + ' records'"></p>
+                        </div>
+                        <button type="button" @click="clearSelection()" x-show="selectedPlayers.length" class="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50" title="Clear selection"><i class="fa-solid fa-xmark text-sm"></i></button>
+                    </div>
+                    <div x-show="selectedPlayers.length === 0" class="px-4 py-10 text-center text-sm text-gray-500">No players selected</div>
+                    <div x-show="selectedPlayers.length > 0" class="divide-y divide-gray-100">
+                        <template x-for="player in selectedPlayers" :key="player.id">
+                            <div class="px-4 py-3">
+                                <label class="flex items-start gap-3 cursor-pointer">
+                                    <input type="radio" name="keep_player" :checked="keepPlayerId === player.id" @change="selectKeep(player.id)" class="mt-1 border-gray-300 text-pines-500 focus:ring-pines-500">
+                                    <span class="min-w-0 flex-1">
+                                        <span class="flex items-center gap-2">
+                                            <span class="text-sm font-semibold text-gray-900 truncate" x-text="player.name"></span>
+                                            <span x-show="keepPlayerId === player.id" class="inline-flex items-center rounded bg-pines-50 px-1.5 py-0.5 text-[11px] font-medium text-pines-700 border border-pines-200">Keep</span>
+                                        </span>
+                                        <span class="block text-xs text-gray-500 truncate" x-text="player.email"></span>
+                                        <span class="block text-xs text-gray-500" x-text="dateLabel(player) + ' | ' + jerseyLabel(player)"></span>
+                                    </span>
+                                </label>
+                            </div>
+                        </template>
+                    </div>
+                </section>
+
+                <section class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                    <div class="px-4 py-3 border-b border-gray-200"><h2 class="text-sm font-semibold text-gray-900">Merge</h2></div>
+                    <div class="p-4 space-y-4">
+                        <div class="grid grid-cols-3 gap-2 text-center">
+                            <div class="rounded-lg border border-gray-200 p-3"><div class="text-lg font-semibold text-gray-900" x-text="keepPlayer ? 1 : 0"></div><div class="text-[11px] uppercase text-gray-500">Kept</div></div>
+                            <div class="rounded-lg border border-gray-200 p-3"><div class="text-lg font-semibold text-gray-900" x-text="mergePlayers.length"></div><div class="text-[11px] uppercase text-gray-500">Removed</div></div>
+                            <div class="rounded-lg border border-gray-200 p-3"><div class="text-lg font-semibold text-gray-900" x-text="selectedRegistrationCount"></div><div class="text-[11px] uppercase text-gray-500">Regs</div></div>
+                        </div>
+                        <div class="rounded-lg bg-gray-50 border border-gray-200 p-3">
+                            <div class="text-xs font-medium text-gray-500 uppercase mb-1">Keeping</div>
+                            <div class="text-sm font-semibold text-gray-900 truncate" x-text="keepPlayer ? keepPlayer.name : 'Choose a record'"></div>
+                            <div class="text-xs text-gray-500 truncate" x-text="keepPlayer ? keepPlayer.email : ''"></div>
+                        </div>
+                        <button type="button" @click="mergeSelected()" :disabled="!canMerge || saving" class="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-pines-500 text-white text-sm font-semibold hover:bg-pines-600 disabled:opacity-50 disabled:cursor-not-allowed">
+                            <i class="fa-solid fa-code-merge text-sm"></i>
+                            <span x-text="saving ? 'Merging...' : 'Merge Selected'"></span>
+                        </button>
+                    </div>
+                </section>
+            </aside>
+        </div>
+    </main>
+
+    <script>
+    function playerMergeApp() {
+        return {
+            loading: true,
+            saving: false,
+            players: [],
+            search: '',
+            selectedIds: [],
+            keepPlayerId: null,
+            successMessage: '',
+            errorMessage: '',
+            async init() { await this.loadPlayers(); },
+            async loadPlayers() {
+                this.loading = true;
+                this.errorMessage = '';
+                try {
+                    const response = await fetch('/api/admin/players');
+                    const data = await response.json();
+                    if (!response.ok) throw new Error(data.detail || 'Failed to load players');
+                    this.players = (data.players || []).sort((a, b) => a.name.localeCompare(b.name));
+                    this.selectedIds = this.selectedIds.filter((id) => this.players.some((player) => player.id === id));
+                    if (!this.selectedIds.includes(this.keepPlayerId)) this.keepPlayerId = this.selectedIds[0] || null;
+                } catch (error) {
+                    this.errorMessage = error.message || 'Failed to load players';
+                } finally {
+                    this.loading = false;
+                }
+            },
+            get filteredPlayers() {
+                const query = this.search.trim().toLowerCase();
+                if (!query) return this.players;
+                return this.players.filter((player) => {
+                    const haystack = [player.name, player.email, player.dateOfBirth, player.birthYear, player.jersey, ...player.registrations.map((reg) => [reg.sport, reg.division, reg.season].join(' '))].join(' ').toLowerCase();
+                    return haystack.includes(query);
+                });
+            },
+            get selectedPlayers() { return this.selectedIds.map((id) => this.players.find((player) => player.id === id)).filter(Boolean); },
+            get keepPlayer() { return this.players.find((player) => player.id === this.keepPlayerId) || null; },
+            get mergePlayers() { return this.selectedPlayers.filter((player) => player.id !== this.keepPlayerId); },
+            get selectedRegistrationCount() { return this.selectedPlayers.reduce((count, player) => count + player.registrations.length, 0); },
+            get canMerge() { return this.selectedPlayers.length >= 2 && this.keepPlayerId && this.mergePlayers.length >= 1; },
+            isSelected(playerId) { return this.selectedIds.includes(playerId); },
+            togglePlayer(player) {
+                if (this.isSelected(player.id)) {
+                    this.selectedIds = this.selectedIds.filter((id) => id !== player.id);
+                    if (this.keepPlayerId === player.id) this.keepPlayerId = this.selectedIds[0] || null;
+                } else {
+                    this.selectedIds.push(player.id);
+                    if (!this.keepPlayerId) this.keepPlayerId = player.id;
+                }
+            },
+            selectKeep(playerId) {
+                if (!this.isSelected(playerId)) this.selectedIds.push(playerId);
+                this.keepPlayerId = playerId;
+            },
+            clearSelection() {
+                this.selectedIds = [];
+                this.keepPlayerId = null;
+            },
+            canonicalName(name) {
+                return (name || '').toLowerCase().replace(/\([^)]*\)/g, ' ').replace(/[^a-z0-9]+/g, ' ').trim().replace(/\s+/g, ' ');
+            },
+            candidateReason(player) {
+                if (this.selectedPlayers.length === 0 || this.isSelected(player.id)) return '';
+                const email = (player.email || '').trim().toLowerCase();
+                const name = this.canonicalName(player.name);
+                for (const selected of this.selectedPlayers) {
+                    if (email && email === (selected.email || '').trim().toLowerCase()) return 'same email';
+                    if (name && name === this.canonicalName(selected.name)) return 'similar name';
+                    if (player.dateOfBirth && selected.dateOfBirth && player.dateOfBirth === selected.dateOfBirth) return 'same DOB';
+                    if (player.birthYear && selected.birthYear && Number(player.birthYear) === Number(selected.birthYear)) return 'same birth year';
+                }
+                return '';
+            },
+            dateLabel(player) {
+                if (player.dateOfBirth) return player.dateOfBirth;
+                if (player.birthYear) return 'Birth year ' + player.birthYear;
+                return 'No DOB';
+            },
+            jerseyLabel(player) { return player.jersey ? 'Jersey #' + player.jersey : 'No jersey'; },
+            registrationLabel(reg) { return [reg.season, reg.sport, reg.division].filter(Boolean).join(' / ') || 'Registration'; },
+            async mergeSelected() {
+                if (!this.canMerge) return;
+                const keepName = this.keepPlayer ? this.keepPlayer.name : 'selected player';
+                const mergeNames = this.mergePlayers.map((player) => player.name).join(', ');
+                if (!window.confirm('Keep ' + keepName + ' and merge ' + mergeNames + '? This removes the duplicate player records.')) return;
+                this.saving = true;
+                this.errorMessage = '';
+                this.successMessage = '';
+                try {
+                    const response = await fetch('/api/admin/players/merge', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ keep_player_id: this.keepPlayerId, merge_player_ids: this.mergePlayers.map((player) => player.id) })
+                    });
+                    const data = await response.json();
+                    if (!response.ok || !data.success) throw new Error(data.detail || data.error || 'Merge failed');
+                    const parts = [
+                        data.deletedPlayers + ' player record' + (data.deletedPlayers === 1 ? '' : 's') + ' removed',
+                        data.movedRegistrations + ' registration' + (data.movedRegistrations === 1 ? '' : 's') + ' moved',
+                        data.combinedRegistrations + ' registration' + (data.combinedRegistrations === 1 ? '' : 's') + ' combined'
+                    ];
+                    this.successMessage = 'Merge complete: ' + parts.join(', ') + '.';
+                    this.selectedIds = [data.keptPlayerId];
+                    this.keepPlayerId = data.keptPlayerId;
+                    await this.loadPlayers();
+                } catch (error) {
+                    this.errorMessage = error.message || 'Merge failed';
+                } finally {
+                    this.saving = false;
+                }
+            }
+        };
+    }
+    </script>
+    <script src="/static/sidebar.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What changed

Adds the missing UI and app wiring for the player merge workflow introduced in PR #195.

- Includes `player_merge_routes.py` in the FastAPI app so `POST /api/admin/players/merge` is active
- Adds `/admin/merge` to render the Merge Duplicate Players screen
- Adds a searchable UI where admins select duplicate player records, choose the record to keep, and merge the others into it

## How to use

After this is merged and deployed, go directly to `/admin/merge`, search for duplicate player records, select at least two, choose which one to keep, then click **Merge Selected**.

## Notes

This follow-up is needed because PR #195 only added the backend route file and did not expose the route/page in the running app.