### PR TITLE
Persist merged player aliases

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,8 +9,13 @@ from sqlalchemy import func
 from jinja2 import Environment, FileSystemLoader
 from app.database import get_db, engine
 from app.models import Base, Player, Registration, EmailTemplate
+from app.player_alias_sync import install_player_alias_sync_patch
 from app.player_dates import parse_date_of_birth
-from app.schema_compat import ensure_player_date_of_birth_column, ensure_player_high_school_column
+from app.schema_compat import (
+    ensure_player_aliases_table,
+    ensure_player_date_of_birth_column,
+    ensure_player_high_school_column,
+)
 import app.models_members  # noqa: F401  — register Member/MemberGuardian tables
 import app.models_seasons  # noqa: F401  — register Team/TeamRoster/TeamStaff tables
 import app.models_evaluations  # noqa: F401  — register Evaluation tables
@@ -26,6 +31,8 @@ from app.player_merge_routes import router as player_merge_router
 Base.metadata.create_all(bind=engine)
 ensure_player_date_of_birth_column(engine)
 ensure_player_high_school_column(engine)
+ensure_player_aliases_table(engine)
+install_player_alias_sync_patch()
 app = FastAPI(title="POSA Jersey Management")
 
 # Static files (sidebar.js, etc.)

--- a/app/models.py
+++ b/app/models.py
@@ -18,11 +18,24 @@ class Player(Base):
     locked = Column(Boolean, default=False)
 
     registrations = relationship("Registration", back_populates="player", cascade="all, delete-orphan")
+    aliases = relationship("PlayerAlias", back_populates="player", cascade="all, delete-orphan")
 
     __table_args__ = (
         UniqueConstraint("full_name", name="uq_fullname"),
         Index('ix_player_birth_jersey', 'birth_year', 'jersey_number'),
     )
+
+
+class PlayerAlias(Base):
+    __tablename__ = "player_aliases"
+
+    id = Column(Integer, primary_key=True, index=True)
+    player_id = Column(Integer, ForeignKey("players.id"), nullable=False, index=True)
+    alias_name = Column(String, nullable=False)
+    normalized_alias = Column(String, nullable=False, unique=True, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    player = relationship("Player", back_populates="aliases")
 
 
 class Registration(Base):

--- a/app/player_alias_sync.py
+++ b/app/player_alias_sync.py
@@ -1,0 +1,29 @@
+"""Install player alias matching into SportsEngine sync."""
+import logging
+
+from app.player_aliases import find_player_by_alias
+
+logger = logging.getLogger(__name__)
+
+
+def install_player_alias_sync_patch() -> None:
+    from app.services import sportsengine
+
+    original_find_existing_player = sportsengine._find_existing_player
+    if getattr(original_find_existing_player, "_player_alias_patched", False):
+        return
+
+    def find_existing_player_with_aliases(db, player_name: str):
+        alias_player = find_player_by_alias(db, player_name)
+        if alias_player:
+            logger.info(
+                "SYNC: Player alias match: incoming '%s' matched kept '%s'",
+                player_name,
+                alias_player.full_name,
+            )
+            return alias_player
+
+        return original_find_existing_player(db, player_name)
+
+    find_existing_player_with_aliases._player_alias_patched = True
+    sportsengine._find_existing_player = find_existing_player_with_aliases

--- a/app/player_aliases.py
+++ b/app/player_aliases.py
@@ -1,0 +1,45 @@
+"""Helpers for matching merged player names during imports."""
+import re
+from typing import Optional
+
+from sqlalchemy.orm import Session, joinedload
+
+from app.models import Player, PlayerAlias
+
+
+def normalize_player_alias(name: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", " ", (name or "").lower())
+    return " ".join(cleaned.split())
+
+
+def find_player_by_alias(db: Session, name: str) -> Optional[Player]:
+    normalized = normalize_player_alias(name)
+    if not normalized:
+        return None
+
+    alias = db.query(PlayerAlias).options(joinedload(PlayerAlias.player)).filter(
+        PlayerAlias.normalized_alias == normalized
+    ).first()
+    return alias.player if alias else None
+
+
+def upsert_player_alias(db: Session, player_id: int, alias_name: str) -> Optional[PlayerAlias]:
+    normalized = normalize_player_alias(alias_name)
+    if not normalized:
+        return None
+
+    alias = db.query(PlayerAlias).filter(
+        PlayerAlias.normalized_alias == normalized
+    ).first()
+    if alias:
+        alias.player_id = player_id
+        alias.alias_name = alias_name
+        return alias
+
+    alias = PlayerAlias(
+        player_id=player_id,
+        alias_name=alias_name,
+        normalized_alias=normalized,
+    )
+    db.add(alias)
+    return alias

--- a/app/player_merge_routes.py
+++ b/app/player_merge_routes.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
 from app.models import Player, Registration
+from app.player_aliases import upsert_player_alias
 from app.player_dates import date_of_birth_iso
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
@@ -135,7 +136,11 @@ def merge_players(payload: Dict[str, Any] = Body(...), db: Session = Depends(get
     updated_fields = []
 
     try:
+        upsert_player_alias(db, keep_player.id, keep_player.full_name)
+
         for duplicate_player in duplicate_players:
+            upsert_player_alias(db, keep_player.id, duplicate_player.full_name)
+
             if not keep_player.date_of_birth and duplicate_player.date_of_birth:
                 keep_player.date_of_birth = duplicate_player.date_of_birth
                 updated_fields.append("date_of_birth")

--- a/app/schema_compat.py
+++ b/app/schema_compat.py
@@ -44,3 +44,35 @@ def ensure_player_high_school_column(engine) -> None:
         )
 
     logger.info("Added players.is_high_school column")
+
+
+def ensure_player_aliases_table(engine) -> None:
+    """Add player aliases table for existing databases created before player merging."""
+    inspector = inspect(engine)
+    if "players" not in inspector.get_table_names():
+        return
+    if "player_aliases" in inspector.get_table_names():
+        return
+
+    dialect = engine.dialect.name
+    id_column = "INTEGER PRIMARY KEY AUTOINCREMENT" if dialect == "sqlite" else "SERIAL PRIMARY KEY"
+    created_at_column = "DATETIME DEFAULT CURRENT_TIMESTAMP" if dialect == "sqlite" else "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+
+    with engine.begin() as conn:
+        conn.execute(text(f"""
+            CREATE TABLE IF NOT EXISTS player_aliases (
+                id {id_column},
+                player_id INTEGER NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+                alias_name VARCHAR NOT NULL,
+                normalized_alias VARCHAR NOT NULL,
+                created_at {created_at_column}
+            )
+        """))
+        conn.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_player_aliases_player_id ON player_aliases (player_id)")
+        )
+        conn.execute(
+            text("CREATE UNIQUE INDEX IF NOT EXISTS ix_player_aliases_normalized_alias ON player_aliases (normalized_alias)")
+        )
+
+    logger.info("Added player_aliases table")

--- a/tests/test_player_aliases.py
+++ b/tests/test_player_aliases.py
@@ -1,0 +1,87 @@
+import os
+from datetime import date
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models import Player, PlayerAlias
+from app.player_aliases import find_player_by_alias, normalize_player_alias
+from app.player_alias_sync import install_player_alias_sync_patch
+from app.player_merge_routes import merge_players
+from app.services import sportsengine
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_merge_saves_duplicate_name_as_sync_alias():
+    db = _session()
+    keep_player = Player(
+        full_name="Avery Johnson",
+        parent_email="primary@example.com",
+        date_of_birth=date(2018, 4, 9),
+        birth_year=2018,
+    )
+    duplicate_player = Player(
+        full_name="Avery J Johnson",
+        parent_email="other@example.com",
+        date_of_birth=date(2018, 4, 9),
+        birth_year=2018,
+    )
+    db.add_all([keep_player, duplicate_player])
+    db.commit()
+
+    result = merge_players(
+        {
+            "keep_player_id": keep_player.id,
+            "merge_player_ids": [duplicate_player.id],
+        },
+        db=db,
+    )
+
+    alias_player = find_player_by_alias(db, "Avery J. Johnson")
+
+    assert result["success"] is True
+    assert alias_player.id == keep_player.id
+    assert db.query(Player).filter(Player.full_name == "Avery J Johnson").first() is None
+    assert db.query(PlayerAlias).filter(
+        PlayerAlias.normalized_alias == normalize_player_alias("Avery J Johnson")
+    ).one().player_id == keep_player.id
+
+
+def test_sportsengine_sync_matches_saved_player_alias():
+    db = _session()
+    keep_player = Player(
+        full_name="Avery Johnson",
+        parent_email="primary@example.com",
+        date_of_birth=date(2018, 4, 9),
+        birth_year=2018,
+    )
+    duplicate_player = Player(
+        full_name="Avery J Johnson",
+        parent_email="other@example.com",
+        date_of_birth=date(2018, 4, 9),
+        birth_year=2018,
+    )
+    db.add_all([keep_player, duplicate_player])
+    db.commit()
+
+    merge_players(
+        {
+            "keep_player_id": keep_player.id,
+            "merge_player_ids": [duplicate_player.id],
+        },
+        db=db,
+    )
+    install_player_alias_sync_patch()
+
+    matched_player = sportsengine._find_existing_player(db, "Avery J. Johnson")
+
+    assert matched_player.id == keep_player.id


### PR DESCRIPTION
## What changed

- Adds a `player_aliases` table to remember alternate names for a kept player.
- Saves the kept name and each merged-away duplicate name whenever players are merged.
- Installs alias matching into the SportsEngine sync flow so a future import with an old/slightly different name resolves to the kept player instead of recreating the duplicate.
- Adds regression coverage for merge alias persistence and sync matching.

## Why

The merge feature removed duplicate player rows, but SportsEngine could later send the discarded name again. Since the app had no lasting record of that alias, sync treated it as a new player and brought the duplicate back.

## Validation

- Direct in-memory regression check passed locally: merge a duplicate name, then match the old name through the SportsEngine player matcher.
- Python syntax check passed for the changed files with bytecode output redirected to `/tmp`.
- The local virtual environment is missing `pytest` and `requests`, so the full pytest command could not be run in this checkout.